### PR TITLE
Build glossary from  terms in partial Asciidoc files

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,7 @@
 = Antora Extensions and Macros for Redpanda Docs
-:url-project: https://github.com/redpanda-data/docs-extensions-and-macros
+:url-org: https://github.com/redpanda-data
+:url-project: {url-org}/docs-extensions-and-macros
+:url-playbook: {url-org}/docs-site
 :url-git: https://git-scm.com
 :url-git-dl: {url-git}/downloads
 :url-nodejs: https://nodejs.org
@@ -97,33 +99,7 @@ antora:
 
 === Global attributes
 
-This extension fetches the content of all YAML files in a GitHub directory and merges the contents with the `asciidoc.attributes` object in the Antora playbook. This allows you to define Asciidoc attributes in an external repository and automatically include them in your documentation.
-
-[IMPORTANT]
-====
-- The GitHub directory that contains the global attributes must be named `global-attributes`.
-- Only YAML files are supported. Other types of files are ignored.
-- If a key is present in both the global attributes and the playbook's `asciidoc.attributes`, the value in the playbook takes precedence.
-====
-
-==== Environment variables
-
-- `GLOBAL_ATTRIBUTES_GITHUB_TOKEN` (optional): A Personal access token (PAT) that has `repo` permissions for the GitHub organization defined in `org`.
-
-NOTE: If you don't set the environment variable, global attributes may not be made available to your build. When the environment variable is not set, the extension sends unauthenticated requests to GitHub. Unauthenticated requests may result in hitting the API rate limit and cause GitHub to reject the request.
-
-==== Configuration options
-
-The extension accepts the following configuration options:
-
-org (required)::
-The GitHub organization that owns the repository.
-
-repo (required)::
-The name of the repository.
-
-branch (required)::
-The branch in the repository where the global attributes are located.
+This extension collects Asciidoc attributes from the {url-playbook}[`shared` component] and makes them available to all component versions. Having global attributes is useful for consistent configuration of local and production builds.
 
 ==== Registration example
 
@@ -131,9 +107,6 @@ The branch in the repository where the global attributes are located.
 antora:
   extensions:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/add-global-attributes'
-    org: example
-    repo: test
-    branch: main
 ```
 
 === Replace attributes in attachments
@@ -153,6 +126,27 @@ This extension replaces AsciiDoc attribute placeholders with their respective va
 antora:
   extensions:
   - '@redpanda-data/docs-extensions-and-macros/extensions/replace-attributes-in-attachments'
+```
+
+=== Aggregate terms
+
+This extension aggregates all term pages from the {url-playbook}[`shared` component] and does the following:
+
+- Makes all `term-name` and `hover-text` attributes available to the <<glossterm-macro,`glossterm` macro>>.
+- Looks for glossary pages named `reference:glossary.adoc` in all versions of the Redpanda docs and appends the contents of each term file to the glossary in alphabetical order.
+- If a glossary page is found, sets the `glossary-page` attribute of the `glossterm` macro to `reference:glossary.adoc`.
+
+[IMPORTANT]
+====
+By default, this extension processes glossary pages for the `ROOT` (redpanda) component only. This behavior is hardcoded and cannot be changed in the configuration.
+====
+
+==== Registration example
+
+```yaml
+antora:
+  extensions:
+  - '@redpanda-data/docs-extensions-and-macros/extensions/aggregate-terms'
 ```
 
 === Unlisted pages
@@ -231,30 +225,19 @@ asciidoc:
     - '@redpanda-data/docs-extensions-and-macros/macros/config-ref'
 ----
 
-=== glossary and glossterm
+=== glossterm
 
-The glossary module provides a way to define and reference glossary terms in your AsciiDoc documents.
+The `glossterm` inline macro provides a way to define and reference glossary terms in your AsciiDoc documents.
 
-This module consists of two parts: a block macro (`glossary`) and an inline macro (`glossterm`).
-
-NOTE: This macro is a customized version of https://gitlab.com/djencks/asciidoctor-glossary[`asciidoctor-glossary`]. We added the ability to define terms globally in <<global-attributes, global attributes>> as well as link to external URLs.
+NOTE: This macro is a customized version of https://gitlab.com/djencks/asciidoctor-glossary[`asciidoctor-glossary`].
 
 ==== Usage
 
-To insert a glossary dlist, use the glossary block macro.
+Use the `glossterm` inline macro to reference a term within the text of the document:
 
 [,asciidoc]
 ----
-glossary::[]
-----
-
-Glossary terms defined in the `glossterm` inline macro before the `glossary` macro is used appear as a definition list, sorted by term.
-
-The `glossterm` inline macro is used to reference a term within the text of the document:
-
-[,asciidoc]
-----
-glossterm:myTerm[myDefinition]
+glossterm:my term[myDefinition]
 ----
 
 It takes two parameters:
@@ -263,7 +246,7 @@ term::
 The term to be defined.
 
 definition (optional)::
-The definition of the term. If the term is defined in the <<global-attributes, global attributes>>, you can omit the definition as it will always be replaced by the definition in the global attributes.
+The definition of the term. If the term is defined in the {url-playbook}[`shared` component] or the `local-terms` object of the `antora.yml` file, you can omit the definition as it will always be replaced by those definitions.
 
 ==== Configuration options
 
@@ -289,15 +272,6 @@ Whether to enable tooltips for the defined terms. Valid values are:
 - data-<attribute-name>​: This inserts the definition as the value of the supplied attribute name, which must start with `data`.
 
 The last two options are intended to support js/css tooltip solutions such as tippy.js.
-
-[IMPORTANT]
-.Multi-page use
-====
-In Antora, a glossary is constructed for each component-version.
-When the `glossary` block macro is evaluated, only terms known as of the rendering can be included.
-Therefore, it is necessary that the page containing this macro in a component-version be rendered last.
-It may be possible to arrange this by naming the page starting with a lot of 'z’s, such as `zzzzzz-glossary.adoc`.
-====
 
 ==== Registration example
 

--- a/extensions/add-global-attributes.js
+++ b/extensions/add-global-attributes.js
@@ -2,76 +2,43 @@
 * antora:
     extensions:
  *    - require: ./extensions/add-global-attributes.js
-       org: example
-       repo: test
-       branch: main
 */
 
-const yaml = require('js-yaml');
-const { Octokit } = require("@octokit/rest");
-const { retry } = require("@octokit/plugin-retry");
-const OctokitWithRetries = Octokit.plugin(retry);
-const chalk = require('chalk')
-
-
 module.exports.register = function ({ config }) {
-  const logger = this.getLogger('global-attributes-extension')
+  const yaml = require('js-yaml');
+  const _ = require('lodash');
+  const logger = this.getLogger('global-attributes-extension');
+  const chalk = require('chalk')
 
-  this
-    .on('playbookBuilt', async ({ playbook }) => {
-
-      const globalAttributesUrl = `/repos/${config.org}/${config.repo}/contents/global-attributes?ref=${config.branch}`;
-
-      let githubOptions = {
-        userAgent: 'Redpanda Docs',
-        baseUrl: 'https://api.github.com',
-      };
-
-      if(process.env.GLOBAL_ATTRIBUTES_GITHUB_TOKEN){
-        githubOptions.auth = process.env.GLOBAL_ATTRIBUTES_GITHUB_TOKEN;
-      } else {
-        logger.warn('GLOBAL_ATTRIBUTES_GITHUB_TOKEN environment variable not set. Attempting unauthenticated request.')
-      }
-
-      const github = new OctokitWithRetries(githubOptions);
-
-      try {
-        // Request the contents of the directory from the GitHub API
-        const response = await github.request('GET ' + globalAttributesUrl);
-
-        if (response.status === 200) {
-          const directoryContents = response.data;
-
-          // Filter out only YAML files
-          const yamlFiles = directoryContents.filter(file => file.name.endsWith('.yaml') || file.name.endsWith('.yml'));
-
-          let globalAttributes = {};
-          for (let file of yamlFiles) {
-            const fileResponse = await github.request('GET ' + file.download_url);
-            const fileData = yaml.load(fileResponse.data);
-            globalAttributes = {...globalAttributes, ...fileData};
+  this.on('contentAggregated', ({ siteCatalog, contentAggregate }) => {
+    let attributeFile;
+    try {
+      for (const component of contentAggregate) {
+        if (component.name === 'shared') {
+          attributeFile = component.files.find(file => file.path.includes('attributes.yml'));
+          if (!attributeFile) {
+            logger.warn("No attributes.yml file found in 'shared' component.");
+          } else {
+            siteCatalog.attributeFile = yaml.load(attributeFile.contents.toString('utf8'));
+            console.log(chalk.green('Loaded attributes from shared component.'));
           }
-
-          let mergedAttributes = {
-            ...globalAttributes,
-            ...playbook.asciidoc.attributes
-          };
-
-          playbook.asciidoc.attributes = mergedAttributes;
-
-          console.log(chalk.green('Merged global attributes into playbook'));
-
-        } else {
-          logger.warn(`Could not fetch global attributes: ${response.statusText}`);
-          return null
-        }
-      } catch(error) {
-        if (error.response.url) {
-          logger.warn(error.status + ' Could not get ' + error.response.url)
-        }
-        else {
-          logger.warn(error)
+          break
         }
       }
-    })
+    } catch (error) {
+      logger.error(`Error loading attributes: ${error.message}`);
+    }
+  })
+
+  .on('contentClassified', ({ siteCatalog, contentCatalog }) => {
+    const components = contentCatalog.getComponents()
+    try {
+      components.forEach(({asciidoc}) => {
+        asciidoc.attributes = _.merge(asciidoc.attributes, siteCatalog.attributeFile);
+      });
+      console.log(chalk.green('Merged global attributes into each component.'));
+    } catch (error) {
+      logger.error(`Error merging attributes: ${error.message}`);
+    }
+  });
 }

--- a/extensions/aggregate-terms.js
+++ b/extensions/aggregate-terms.js
@@ -1,0 +1,60 @@
+/* Example use in the playbook
+* antora:
+    extensions:
+ *    - require: ./extensions/aggregate-terms.js
+*/
+
+module.exports.register = function ({ config }) {
+  const logger = this.getLogger('term-aggregation-extension');
+  const chalk = require('chalk')
+
+  this.on('contentAggregated', ({ siteCatalog, contentAggregate }) => {
+    try {
+      for (const component of contentAggregate) {
+        if (component.name === 'shared') {
+          const termFiles = component.files.filter(file => file.path.includes('modules/terms/partials/'));
+          siteCatalog.terms = {}
+          termFiles.forEach(file => {
+            const termContent = file.contents.toString('utf8');
+            siteCatalog.terms[file.basename] = termContent;
+          });
+          console.log(chalk.green('Loaded terms from shared component.'));
+          break
+        }
+      }
+    } catch (error) {
+      logger.error(`Error loading terms: ${error.message}`);
+    }
+  })
+
+  .on('contentClassified', ({ siteCatalog, contentCatalog }) => {
+    const components = contentCatalog.getComponents()
+    try {
+      for (const { versions } of components) {
+        for (const { name: component, version, asciidoc, title } of versions) {
+          // TODO: will need a better way to filter when we have more content components
+          if (component !== 'ROOT') continue;
+          const glossaryPage = contentCatalog.resolvePage(`${version?version +'@':''}${component}:reference:glossary.adoc`);
+          if (glossaryPage) {
+            asciidoc.attributes['glossary-page'] = 'reference:glossary.adoc'
+            const glossaryContent = glossaryPage.contents.toString('utf8');
+            let newContent = glossaryContent;
+            const sortedTerms = Object.keys(siteCatalog.terms).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+            for (i = 0; i < sortedTerms.length; i++) {
+              const termName = sortedTerms[i];
+              const termContent = siteCatalog.terms[termName];
+              newContent += '\n\n' + termContent;
+            }
+            glossaryPage.contents = Buffer.from(newContent, 'utf8');
+
+            console.log(chalk.green(`Transposed terms into glossary for ${component}.`));
+          } else {
+            logger.warn(`Skipping ${title} ${version} - No glossary page (reference:glossary.adoc) found`)
+          }
+        }
+      }
+    } catch (error) {
+      logger.error(`Error transposing terms: ${error.message}`);
+    }
+  });
+}

--- a/extensions/replace-attributes-in-attachments.js
+++ b/extensions/replace-attributes-in-attachments.js
@@ -7,6 +7,7 @@ module.exports.register = function ({ config }) {
   this.on('documentsConverted', ({playbook, contentCatalog}) => {
     for (const { versions } of contentCatalog.getComponents()) {
       for (const { name: component, version } of versions) {
+        // TODO: will need a better way to filter when we have more content components
         if (component !== 'ROOT') continue;
         const attachments = contentCatalog.findBy({ component, version, family });
         for (const attachment of attachments) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "gulp-connect": "^5.7.0",
         "html-entities": "2.3",
         "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
         "node-html-parser": "5.4.2-0"
       }
     },
@@ -3398,6 +3399,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,14 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "2.5.1",
+  "version": "3.0.0",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
-  "keywords": ["antora", "extension", "macro", "documentation", "redpanda"],
+  "keywords": [
+    "antora",
+    "extension",
+    "macro",
+    "documentation",
+    "redpanda"
+  ],
   "author": {
     "name": "Redpanda Docs Team"
   },
@@ -39,10 +45,11 @@
     "@octokit/rest": "^19.0.7",
     "algoliasearch": "^4.17.0",
     "chalk": "4.1.2",
-    "js-yaml": "^4.1.0",
     "gulp": "^4.0.2",
     "gulp-connect": "^5.7.0",
     "html-entities": "2.3",
+    "js-yaml": "^4.1.0",
+    "lodash": "^4.17.21",
     "node-html-parser": "5.4.2-0"
   }
 }


### PR DESCRIPTION
Allows writers to define terms in partial files in the `shared` component of `redpanda-data/docs-site/shared/modules/terms/partials`. Each term must be in its own file and include the following attributes:

- `term-name`: Name of the term
- `hover-text`: Description that will appear in the tooltip

Term files can include any valid Asciidoc markup.