### PR TITLE
Fix bug that caused Maximum call stack size exceeded error

### DIFF
--- a/extensions/replace-attributes-in-attachments.js
+++ b/extensions/replace-attributes-in-attachments.js
@@ -8,8 +8,9 @@ module.exports.register = function ({ config }) {
     for (const { versions } of contentCatalog.getComponents()) {
       for (const { name: component, version, asciidoc } of versions) {
         const attachments = contentCatalog.findBy({ component, version, family });
+        if (component == 'api') continue
         for (const attachment of attachments) {
-          let contentString = String.fromCharCode(...attachment['_contents']);
+          let contentString = attachment['_contents'].toString('utf8');
           if (!asciidoc.attributes) continue
           if (!asciidoc.attributes.hasOwnProperty('replace-attributes-in-attachments')) continue;
           for (const key in asciidoc.attributes) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
Came across this bug after adding the new `admin-api.yaml` OpenAPI spec attachment.

`String.fromCharCode(...attachment['_contents'])` attempts to pass each byte from the buffer as an individual argument. Because JavaScript functions have a maximum number of arguments they can accept, using the spread syntax with a large buffer can exceed this limit, leading to a "Maximum call stack size exceeded" error.