### PR TITLE
Improve logging in Algolia extension

### DIFF
--- a/extensions/algolia-indexer/index.js
+++ b/extensions/algolia-indexer/index.js
@@ -45,7 +45,7 @@ function register ({
         algoliaCount += algolia[c][v].length
         // Save all records to the index
         index.saveObjects(algolia[c][v]).then(() => {
-          console.log(`${chalk.bold(algoliaCount)} Algolia index entries created`)
+          console.log(`Indexed ${c} version ${v}`)
         }).catch(error => {
           console.error(`Error saving objects to Algolia: ${error}`);
         });
@@ -78,7 +78,7 @@ function register ({
       .then(() => {
         console.log('Total Records:', recordCount);
       })
-      .catch(err => console.log(err));
+      .catch(err => console.log(JSON.stringify(err)));
   })
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.6",
+  "version": "3.0.7c",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.0.6",
+      "version": "3.0.7c",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "^4.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.7c",
+  "version": "3.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.0.7c",
+      "version": "3.0.7",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.6",
+  "version": "3.0.7c",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.7c",
+  "version": "3.0.7",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
- Algolia returns an object so we serialize it as JSON to avoid seeing `[object Object]` in logs.
- Log the component name and version that was successfully indexed rather than repeating the total number of records.