### PR TITLE
Remove images from Algolia index

### DIFF
--- a/extensions/algolia-indexer/generate-index.js
+++ b/extensions/algolia-indexer/generate-index.js
@@ -69,7 +69,6 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
     // "current" component version.
     // When indexLatestOnly is set, we only index the current version.
     const component = contentCatalog.getComponent(page.src.component)
-    const home = contentCatalog.getComponent('home')
     const thisVersion = contentCatalog.getComponentVersion(component, page.src.version)
     const latestVersion = component.latest
     const isCurrent = thisVersion === latestVersion
@@ -101,26 +100,6 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
           t: elem.text
         })
       })
-
-    const images = {
-      'get started': 'get-started-icon.png',
-      'develop': 'develop-icon.png',
-      'deploy': 'deploy-icon.png',
-      'manage': 'manage-icon.png'
-    }
-
-    var image = {}
-
-    if (breadcrumbs.length > 1) {
-      const lowercaseBreadcrumb = breadcrumbs[1].t.toLowerCase()
-      for (let key in images) {
-        if (lowercaseBreadcrumb.includes(key)) {
-          image.src = `${home.url}_images/${images[key]}`
-          image.alt = key
-          break
-        }
-      }
-    }
 
     // Start handling the article content
     const article = root.querySelector('article.doc')
@@ -178,7 +157,7 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
       title: documentTitle,
       product: component.title,
       version: version,
-      image: image? image: '',
+      //image: image? image: '',
       //text: text,
       breadcrumbs: breadcrumbs,
       intro: intro,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.0.8",
+      "version": "3.0.9",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
When we replaced the global `home` component with versioned home pages, this extension broke because we were pulling images from that component.

Removing images from the Algolia index for now. If needed, they can be added as a future improvement.