### PR TITLE
Lower log level for missing glossary page

### DIFF
--- a/extensions/aggregate-terms.js
+++ b/extensions/aggregate-terms.js
@@ -66,7 +66,7 @@ module.exports.register = function ({ config }) {
 
             console.log(chalk.green(`Merged terms into glossary for ${component} component${version? version: ''}.`));
           } else {
-            logger.warn(`Skipping ${title} ${version} - No glossary page (reference:glossary.adoc) found`)
+            logger.info(`Skipping ${title} ${version} - No glossary page (reference:glossary.adoc) found`)
           }
         }
       }

--- a/macros/glossary.js
+++ b/macros/glossary.js
@@ -135,7 +135,7 @@ module.exports.register = function (registry, config = {}) {
         const termExistsInContext = context.gloss.some((candidate) => candidate.term === term);
         if ((termExistsInContext && links) || (links && customLink)) {
           inline = customLink
-            ? self.createInline(parent, 'anchor', target, { type: 'link', target: customLink, attributes: attrs })
+            ? self.createInline(parent, 'anchor', target, { type: 'link', target: customLink, attributes: { ...attrs, window: '_blank', rel: 'noopener noreferrer' } })
             : self.createInline(parent, 'anchor', target, { type: 'xref', target: `${glossaryPage}#${termId(term)}`, reftext: target, attributes: attrs })
         } else {
           inline = self.createInline(parent, 'quoted', target, { attributes: attrs })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.0.10,
+      "version": "3.0.11",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
It's distracting to see lots of `WARN (term-aggregation-extension): Skipping Redpanda 22.2 - No glossary page`  in the logs on every build. By lowering this log level, it won't be output by default. We can choose to see these logs by editing the log level in the playbook: https://docs.antora.org/antora/latest/playbook/runtime-log-level/

Also, this PR makes sure that external term links open a new window.