### PR TITLE
Skip index for pages with no H1

### DIFF
--- a/extensions/algolia-indexer/generate-index.js
+++ b/extensions/algolia-indexer/generate-index.js
@@ -111,8 +111,8 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
     // handle titles
     const h1 = article.querySelector('h1')
     if (!h1) {
-      logger.error(`No H1 in ${page.pub.url}`)
-      process.exit(1)
+      logger.warn(`No H1 in ${page.pub.url}...skipping`)
+      continue
     }
     const documentTitle = h1.text
     h1.remove()

--- a/extensions/replace-attributes-in-attachments.js
+++ b/extensions/replace-attributes-in-attachments.js
@@ -12,7 +12,6 @@ module.exports.register = function ({ config }) {
         for (const attachment of attachments) {
           let contentString = attachment['_contents'].toString('utf8');
           if (!asciidoc.attributes) continue
-          if (!asciidoc.attributes.hasOwnProperty('replace-attributes-in-attachments')) continue;
           for (const key in asciidoc.attributes) {
             const placeholder = "{" + key + "}";
             const sanitizedValue = sanitizeAttributeValue(asciidoc.attributes[key]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.0.11",
+      "version": "3.0.12",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
We recently had a case where an autogenerated page was missing an H1 and this error was causing the whole build to fail.

This PR allows the build to continue and logs a warning that the page will not be indexed because it is missing an H1.

Also fixes https://github.com/redpanda-data/documentation/issues/1870 by [removing the check for a specific attribute](https://github.com/redpanda-data/docs-extensions-and-macros/pull/16/files#diff-9532e6ee5af06dee5442ee46e82b23ebc9faaaf92138d8c0afb24078a6fb3003) before replacing them in attachment files.