### PR TITLE
feat: add support for setting line numbers on code blocks

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,7 +40,7 @@ npm i @redpanda-data/docs-extensions-and-macros
 
 To use the development version instead, refer to the <<development-quickstart,Development Quickstart>>.
 
-== Extensions
+== Antora Extensions
 
 This section documents the Antora extensions that are provided by this library and how to configure them.
 
@@ -168,6 +168,24 @@ antora:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/unlisted-pages'
     addToNavigation: true
     unlistedPagesHeading: 'Additional Resources'
+```
+
+== Asciidoc Extensions
+
+This section documents the Asciidoc extensions that are provided by this library and how to configure them.
+
+IMPORTANT: Be sure to register each extension under the `asciidoc.extensions` key in the playbook, not the `antora.extensions` key.
+
+=== Add line numbers and highlights
+
+This extension adds the necessary classes to make line numbers and line highlighting work with Prism.js.
+
+==== Registration example
+
+```yaml
+antora:
+  extensions:
+  - '@redpanda-data/docs-extensions-and-macros/asciidoc-extensions/add-line-numbers-highlights'
 ```
 
 == Macros

--- a/asciidoc-extensions/add-line-numbers-highlights.js
+++ b/asciidoc-extensions/add-line-numbers-highlights.js
@@ -6,11 +6,17 @@ function addLineNumbersAndCodeHighlightingAttributes() {
       // Iterate through all attributes of the listing block
       for (let key in attributes) {
         if (key.startsWith('lines')) {
-            if (attributes.role) {
-              listingBlock.setAttribute('role', attributes.role + ' ' + `${key}-${attributes[key]}`);
-            } else {
-              listingBlock.setAttribute('role', `${key}-${attributes[key]} line-numbers`);
+          let newRoleValue = `${key}-${attributes[key]}`;
+
+          if (attributes.role) {
+            if (!attributes.role.includes('line-numbers')) {
+              newRoleValue += ' line-numbers';
             }
+            listingBlock.setAttribute('role', attributes.role + ' ' + newRoleValue);
+          } else {
+            newRoleValue += ' line-numbers';
+            listingBlock.setAttribute('role', newRoleValue);
+          }
         }
       }
     }

--- a/asciidoc-extensions/add-line-numbers-highlights.js
+++ b/asciidoc-extensions/add-line-numbers-highlights.js
@@ -1,0 +1,24 @@
+function addLineNumbersAndCodeHighlightingAttributes() {
+  this.process((doc) => {
+    for (const listingBlock of doc.findBy({ context: 'listing' })) {
+      const attributes = listingBlock.getAttributes();
+
+      // Iterate through all attributes of the listing block
+      for (let key in attributes) {
+        if (key.startsWith('lines')) {
+            if (attributes.role) {
+              listingBlock.setAttribute('role', attributes.role + ' ' + `${key}-${attributes[key]}`);
+            } else {
+              listingBlock.setAttribute('role', `${key}-${attributes[key]} line-numbers`);
+            }
+        }
+      }
+    }
+  });
+}
+
+function register(registry, { file }) {
+  registry.treeProcessor(addLineNumbersAndCodeHighlightingAttributes)
+}
+
+module.exports.register = register;

--- a/extensions/replace-attributes-in-attachments.js
+++ b/extensions/replace-attributes-in-attachments.js
@@ -12,7 +12,6 @@ module.exports.register = function ({ config }) {
         for (const attachment of attachments) {
           let contentString = attachment['_contents'].toString('utf8');
           if (!asciidoc.attributes) continue
-          if (!asciidoc.attributes.hasOwnProperty('replace-attributes-in-attachments')) continue;
           for (const key in asciidoc.attributes) {
             const placeholder = "{" + key + "}";
             const sanitizedValue = sanitizeAttributeValue(asciidoc.attributes[key]);

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -19,6 +19,7 @@ asciidoc:
   - './macros/glossary'
   - './macros/config-ref'
   - './macros/helm-ref'
+  - './asciidoc-extensions/add-line-numbers-highlights'
 antora:
   extensions:
   - require: './extensions/add-global-attributes'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.11",
+  "version": "3.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.0.11",
+      "version": "3.0.13",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.11",
+  "version": "3.0.13",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",
@@ -23,6 +23,9 @@
     }
   ],
   "exports": {
+    "./asciidoc-extensions/add-line-numbers-highlights": {
+      "require": "./asciidoc-extensions/add-line-numbers-highlights.js"
+    },
     "./extensions/unlisted-pages": {
       "require": "./extensions/unlisted-pages.js"
     },
@@ -37,6 +40,7 @@
   },
   "files": [
     "extensions",
+    "asciidoc-extensions",
     "macros"
   ],
   "license": "ISC",

--- a/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
@@ -70,3 +70,15 @@ The `version fetcher` extension gets the latest version of Redpanda and Redpanda
 By default, Antora does not replace attributes in attachment files. Download this test attachment to make sure that the `replace-attributes-in-attachments` extension replaces the `test-attribute`:
 
 xref:preview:ROOT:attachment$test.yaml[Download attachment]
+
+== Code highlights
+
+[source,js,lines=1-3+5+6]
+----
+function helloWorld() {
+    console.log("Hello, World!") <sample>;
+    console.log("This is a sample.");
+    console.log("With multiple lines.");
+    console.log("Highlighted using Prism.");
+}
+----


### PR DESCRIPTION
Adds an extension to enable writers to specify lines to highlight in code blocks. For example:

```asciidoc
[source,js,lines=1-3+5+6]
----
function helloWorld() {
    console.log("Hello, World!") <sample>;
    console.log("This is a sample.");
    console.log("With multiple lines.");
    console.log("Highlighted using Prism.");
}
----
```

![2023-09-08_17-15-08](https://github.com/redpanda-data/docs-extensions-and-macros/assets/45230295/e03e4f1b-f65a-4212-b9f0-3cc99742c876)


The extension adds the `line-numbers` class to the code block (The [Prism line numbers plugin ](https://prismjs.com/plugins/line-numbers/)requires this to add line numbers). It also takes the `lines` attribute and applies it as another class to the code block. The script in https://github.com/redpanda-data/docs-ui/pull/103 uses the `lines` class to apply the necessary `data-lines` attribute to the `pre` element so that the [Prism line highlight plugin](https://prismjs.com/plugins/line-highlight/#linkable.65) can apply the line highlighting.

The syntax for specifying lines in code blocks is slightly different from how it's documented in the Prism project since we cannot use commas in the value of the attribute:

- A single number refers to the line with that number
- Ranges are denoted by two numbers, separated with a hyphen (-)
- Multiple line numbers or ranges are separated by pluses instead of commas.

Examples:

5
The 5th line
1-5
Lines 1 through 5
1+4
Line 1 and line 4
1-2+5+9-20
Lines 1 through 2, line 5, lines 9 through 20

Relies on https://github.com/redpanda-data/docs-ui/pull/103
