### PR TITLE
Fix version fetcher for Console version

### DIFF
--- a/extensions/add-global-attributes.js
+++ b/extensions/add-global-attributes.js
@@ -6,7 +6,6 @@
 
 module.exports.register = function ({ config }) {
   const yaml = require('js-yaml');
-  const _ = require('lodash');
   const logger = this.getLogger('global-attributes-extension');
   const chalk = require('chalk')
 
@@ -29,18 +28,4 @@ module.exports.register = function ({ config }) {
       logger.error(`Error loading attributes: ${error.message}`);
     }
   })
-
-  .on('contentClassified', ({ siteCatalog, contentCatalog }) => {
-    const components = contentCatalog.getComponents()
-    try {
-      components.forEach(({versions}) => {
-        versions.forEach(({asciidoc}) => {
-          asciidoc.attributes = _.merge(asciidoc.attributes, siteCatalog.attributeFile);
-        })
-      });
-      console.log(chalk.green('Merged global attributes into each component version.'));
-    } catch (error) {
-      logger.error(`Error merging attributes: ${error.message}`);
-    }
-  });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.0.14",
+      "version": "3.0.15",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
The code that merges global attributes into each component was overwriting the Console version that was fetched in `set-latest-version.js`. Since the merging happened in the `contentClassified` event, this PR moves the merge code to the `set-latest-version` to make sure it runs before the latest Console version is set.