### PR TITLE
Add article text to the index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.0.15",
+      "version": "3.0.16",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
We've had some reports that our internal search doesn't produce results for text that is present in the docs.

The issue was that the indexer only grabbed text from headings, breadcrumbs, and the first paragraph. This was due to the limitations we had on record size before we migrated to the Docsearch one.

This PR allows the indexer to grab text from paragraphs, tables, lists, and code blocks.