### PR TITLE
Allow no index pages

### DIFF
--- a/extensions/algolia-indexer/generate-index.js
+++ b/extensions/algolia-indexer/generate-index.js
@@ -59,11 +59,11 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
       }
     )
 
-    // Skip pages marked as "noindex" for "robots"
+    /* Skip pages marked as "noindex" for "robots"
     const noindex = root.querySelector('meta[name=robots][content=noindex]')
     if (noindex) {
       continue
-    }
+    }*/
 
     // Compute a flag identifying if the current page is in the
     // "current" component version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.16",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.0.16",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.0.16",
+  "version": "3.1.0",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
Our beta docs are currently marked as `noindex` to avoid search engines from picking them up since they are ephemeral. But we want the internal search index to pick them up.