### PR TITLE
Allow users to override global attributes

### DIFF
--- a/extensions/add-global-attributes.js
+++ b/extensions/add-global-attributes.js
@@ -8,6 +8,7 @@ module.exports.register = function ({ config }) {
   const yaml = require('js-yaml');
   const logger = this.getLogger('global-attributes-extension');
   const chalk = require('chalk')
+  const _ = require('lodash');
 
   this.on('contentAggregated', ({ siteCatalog, contentAggregate }) => {
     let attributeFile;
@@ -26,6 +27,19 @@ module.exports.register = function ({ config }) {
       }
     } catch (error) {
       logger.error(`Error loading attributes: ${error.message}`);
+    }
+  })
+  .on('contentClassified', async ({ siteCatalog,contentCatalog }) => {
+    const components = await contentCatalog.getComponents();
+    for (let i = 0; i < components.length; i++) {
+      let component = components[i];
+      if (component.name !== 'ROOT' && component.name !== 'preview') continue
+
+      component.versions.forEach(({asciidoc}) => {
+        if (siteCatalog.attributeFile) {
+          asciidoc.attributes = _.merge({}, siteCatalog.attributeFile, asciidoc.attributes);
+        }
+      })
     }
   })
 }

--- a/extensions/algolia-indexer/index.js
+++ b/extensions/algolia-indexer/index.js
@@ -114,7 +114,7 @@ function register({
     }
 
     for (const [objectID, obj] of existingObjectsMap) {
-      if (obj.type === 'Doc' && !obj._tags.includes('apis')) {
+      if (obj.type === 'Doc' && !obj._tags.includes('apis') || !obj.type) {
         objectsToDelete.push(objectID)
       }
     }

--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -7,7 +7,6 @@ antora:
 const GetLatestRedpandaVersion = require('./getLatestRedpandaVersion');
 const GetLatestConsoleVersion = require('./getLatestConsoleVersion');
 const chalk = require('chalk')
-const _ = require('lodash');
 
 
 module.exports.register = function ({ config }) {
@@ -32,9 +31,6 @@ module.exports.register = function ({ config }) {
           if (component.name !== 'ROOT' && component.name !== 'preview') continue
 
           component.versions.forEach(({name, version, asciidoc}) => {
-            if (siteCatalog.attributeFile) {
-              asciidoc.attributes = _.merge(asciidoc.attributes, siteCatalog.attributeFile);
-            }
             if (LatestConsoleVersion) {
               asciidoc.attributes['latest-console-version'] = `${LatestConsoleVersion}`;
               console.log(`${chalk.green('Set Redpanda Console version to')} ${chalk.bold(LatestConsoleVersion)} in ${name} ${version}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
- Allows us to override global attributes. Required for #25 Related PR: https://github.com/redpanda-data/docs-site/pull/39
- Deletes Algolia records that don't have a type. All new records should have a type. Those that don't were part of the old schema.