### PR TITLE
Add unix timestamp to doc records

### DIFF
--- a/extensions/algolia-indexer/generate-index.js
+++ b/extensions/algolia-indexer/generate-index.js
@@ -28,6 +28,8 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
 
   console.log(chalk.cyan('Indexing...'))
 
+  const unixTimestamp = Math.floor(Date.now() / 1000)
+
   // Select indexable pages
   const pages = contentCatalog.getPages((page) => {
     if (!page.out || page.asciidoc?.attributes?.noindex != null) return
@@ -45,7 +47,6 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
   }
   const urlPath = extractUrlPath(siteUrl)
 
-  const documents = {}
   var algoliaCount = 0
 
   for (var i = 0; i < pages.length; i++) {
@@ -181,13 +182,13 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
       title: documentTitle,
       product: component.title,
       version: version,
-      //image: image? image: '',
       text: text,
       breadcrumbs: breadcrumbs,
       intro: intro,
       objectID: urlPath + page.pub.url,
       titles: titles,
       keywords: keywords,
+      unixTimestamp: unixTimestamp,
       type: 'Doc',
       _tags: [tag, 'docs']
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
This is needed as part of https://github.com/redpanda-data/docs-site/pull/40 since all records will be sorted by date. So we make sure that doc pages always have the current date.