### PR TITLE
Add a category validator and related resource finder

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -99,6 +99,75 @@ antora:
   - '@redpanda-data/docs-extensions-and-macros/extensions/version-fetcher/set-latest-version'
 ```
 
+=== Validate attributes
+
+This extension ensures the consistency and validity of page attributes, focusing on validating page categories against a predefined list of valid categories and subcategories. It automatically adds missing parent categories for any specified subcategories and removes any specified categories that are invalid. Additionally, it processes specific environment attributes, setting corresponding page-level attributes when environment conditions are met.
+
+==== Environment variables
+
+This extension does not require any environment variables.
+
+==== Configuration options
+
+There are no configurable options for this extension. It operates based on site attributes defined in `add-global-attributes.js` to determine valid categories and subcategories.
+
+==== Registration example
+
+Register the `validate-attributes` extension in the Antora playbook under the `antora.extensions` key like so:
+
+[source,yaml]
+----
+antora:
+  extensions:
+    - require: '@redpanda-data/docs-extensions-and-macros/extensions/validate-attributes.js'
+----
+
+=== Related docs
+
+This extension enhances the connectivity between lab exercises and relevant documentation by dynamically identifying and linking related documentation pages and other lab exercises based on shared categories and deployment types.
+
+==== Environment variables
+
+This extension operates without requiring any specific environment variables.
+
+==== Configuration options
+
+This extension does not offer configurable options. It uses the inherent attributes of pages to determine relationships based on `page-categories` and deployment types (`env-kubernetes`, `env-linux`, `env-docker`, `page-cloud`).
+
+==== Registration example
+
+To integrate the `related-docs-extension` into your Antora playbook, add it under the `antora.extensions` key as demonstrated below:
+
+[source,yaml]
+----
+antora:
+  extensions:
+    - require: '@redpanda-data/docs-extensions-and-macros/extensions/related-docs-extension.js'
+----
+
+=== Related labs
+
+This extension enriches documentation pages with links to related lab exercises, facilitating a deeper understanding of the content through practical application. It dynamically assigns related labs to each documentation page based on shared categories and deployment types.
+
+==== Environment variables
+
+This extension does not require any environment variables.
+
+==== Configuration options
+
+The extension operates without explicit configuration options. It automatically processes documentation pages to identify and link related labs based on shared `page-categories` attributes and deployment types (`env-kubernetes`, `env-linux`, `env-docker`, `page-cloud`).
+
+==== Registration example
+
+Include the `related-labs-extension` in the Antora playbook under the `antora.extensions` key as follows:
+
+[source,yaml]
+----
+antora:
+  extensions:
+    - require: '@redpanda-data/docs-extensions-and-macros/extensions/related-labs-extension.js'
+----
+
 === Global attributes
 
 This extension collects Asciidoc attributes from the {url-playbook}[`shared` component] and makes them available to all component versions. Having global attributes is useful for consistent configuration of local and production builds.

--- a/extensions/algolia-indexer/generate-index.js
+++ b/extensions/algolia-indexer/generate-index.js
@@ -27,7 +27,6 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
   const algolia = {}
 
   console.log(chalk.cyan('Indexing...'))
-
   const unixTimestamp = Math.floor(Date.now() / 1000)
 
   // Select indexable pages
@@ -176,27 +175,48 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
       .replace(/\s+/g, ' ')
       .trim();
 
-    var tag = `${component.title}-${version}`
+    var tag = `${component.title}${version ? '-' + version : ''}`
+    var indexItem;
+    const deployment = page.asciidoc?.attributes['env-kubernetes'] ? 'Kubernetes' : page.asciidoc?.attributes['env-linux'] ? 'Linux' : page.asciidoc?.attributes['env-docker'] ? 'Docker' : page.asciidoc?.attributes['page-cloud'] ? 'Redpanda Cloud' : ''
 
-    const indexItem = {
-      title: documentTitle,
-      product: component.title,
-      version: version,
-      text: text,
-      breadcrumbs: breadcrumbs,
-      intro: intro,
-      objectID: urlPath + page.pub.url,
-      titles: titles,
-      keywords: keywords,
-      unixTimestamp: unixTimestamp,
-      type: 'Doc',
-      _tags: [tag, 'docs']
+    const categories = page.asciidoc?.attributes['page-categories']
+    ? page.asciidoc.attributes['page-categories'].split(',').map(category => category.trim())
+    : []
+
+    if (component.name !== 'redpanda-labs'){
+      indexItem = {
+        title: documentTitle,
+        product: component.title,
+        version: version,
+        text: text,
+        breadcrumbs: breadcrumbs,
+        intro: intro,
+        objectID: urlPath + page.pub.url,
+        titles: titles,
+        categories,
+        unixTimestamp: unixTimestamp,
+        type: 'Doc',
+        _tags: [tag, 'docs']
+      }
+    } else {
+      indexItem = {
+        title: documentTitle,
+        categories,
+        deployment,
+        version: version,
+        text: text,
+        intro: intro,
+        objectID: urlPath + page.pub.url,
+        titles: titles,
+        unixTimestamp: unixTimestamp,
+        type: 'Lab',
+        interactive: false,
+        _tags: ['labs']
+      }
     }
-
     algolia[cname][version].push(indexItem)
     algoliaCount++
   }
-
   return algolia
 }
 

--- a/extensions/algolia-indexer/index.js
+++ b/extensions/algolia-indexer/index.js
@@ -114,7 +114,7 @@ function register({
     }
 
     for (const [objectID, obj] of existingObjectsMap) {
-      if (obj.type === 'Doc' && !obj._tags.includes('apis') || !obj.type) {
+      if ((obj.type === 'Doc' && !obj._tags.includes('apis')) || (!obj.type) || (obj.type === 'Lab' && !obj.interactive)) {
         objectsToDelete.push(objectID)
       }
     }

--- a/extensions/find-related-docs.js
+++ b/extensions/find-related-docs.js
@@ -1,0 +1,69 @@
+'use strict';
+
+module.exports.register = function ({ config }) {
+  const logger = this.getLogger('related-docs-extension');
+
+  this.on('documentsConverted', async ({ contentCatalog, siteCatalog }) => {
+    const labs = contentCatalog.findBy({ component: 'redpanda-labs', family: 'page' });
+    labs.forEach((labPage) => {
+      const relatedDocs = []
+      const relatedLabs = []
+      const sourceAttributes = labPage.asciidoc.attributes
+      const pageCategories = sourceAttributes['page-categories'];
+      if (!pageCategories) return;
+      const sourceCategoryList = pageCategories.split(',').map(c => c.trim());
+      const sourceDeploymentType = getDeploymentType(sourceAttributes)
+      const docs = contentCatalog.findBy({ component: 'ROOT', family: 'page' });
+      docs.forEach((docPage) => {
+        const related = findRelated(docPage, sourceCategoryList, sourceDeploymentType, logger)
+        related && relatedDocs.push(related)
+      })
+      labs.forEach((targetLabPage) => {
+        if (targetLabPage === labPage) return;
+
+        const related = findRelated(targetLabPage, sourceCategoryList, sourceDeploymentType, logger);
+        if (related) relatedLabs.push(related);
+      });
+
+      // Store related docs and labs in the lab page attributes
+      if (relatedDocs.length > 0) {
+        labPage.asciidoc.attributes['page-related-docs'] = JSON.stringify(relatedDocs);
+      }
+
+      if (relatedLabs.length > 0) {
+        labPage.asciidoc.attributes['page-related-labs'] = JSON.stringify(relatedLabs);
+      }
+
+      if (relatedDocs.length > 0 || relatedLabs.length > 0) {
+        logger.info(`Set related docs and labs attributes for ${labPage.asciidoc.doctitle}`);
+      }
+    })
+  })
+}
+
+function findRelated(docPage, sourceCategoryList, sourceDeploymentType, logger) {
+  const targetAttributes = docPage.asciidoc.attributes
+  const pageCategories = targetAttributes['page-categories'];
+  if (!pageCategories) return null;
+  const targetCategoryList = pageCategories.split(',').map(c => c.trim());
+  const targetDeploymentType = getDeploymentType(targetAttributes)
+  const categoryMatch = hasMatchingCategory(sourceCategoryList, targetCategoryList)
+  if (categoryMatch && (!targetDeploymentType ||sourceDeploymentType === targetDeploymentType)) {
+    return {
+      title: docPage.asciidoc.doctitle,
+      url: docPage.pub.url,
+    }
+  }
+  return null
+}
+
+function getDeploymentType (attributes) {
+  return attributes['env-kubernetes'] ? 'Kubernetes'
+    : attributes['env-linux'] ? 'Linux'
+      : attributes['env-docker'] ? 'Docker'
+        : attributes.cloud ? 'Redpanda Cloud' : ''
+}
+
+function hasMatchingCategory (sourcePageCategories, targetPageCategories) {
+  return sourcePageCategories.every((category) => targetPageCategories.includes(category))
+}

--- a/extensions/find-related-labs.js
+++ b/extensions/find-related-labs.js
@@ -1,0 +1,52 @@
+'use strict';
+
+module.exports.register = function ({ config }) {
+  const logger = this.getLogger('related-labs-extension');
+
+  this.on('documentsConverted', async ({ contentCatalog, siteCatalog }) => {
+    const docs = contentCatalog.findBy({ component: 'ROOT', family: 'page' });
+    docs.forEach((docPage) => {
+      const relatedLabs = []
+      const sourceAttributes = docPage.asciidoc.attributes
+      const pageCategories = sourceAttributes['page-categories'];
+      if (!pageCategories) return;
+      const sourceCategoryList = pageCategories.split(',').map(c => c.trim());
+      const sourceDeploymentType = getDeploymentType(sourceAttributes)
+      const labs = contentCatalog.findBy({ component: 'redpanda-labs', family: 'page' });
+      labs.forEach((labPage) => {
+        const related = findRelated(labPage, sourceCategoryList, sourceDeploymentType, logger)
+        related && relatedLabs.push(related)
+      })
+      if (!relatedLabs.length) return
+      docPage.asciidoc.attributes['page-related-labs'] = JSON.stringify(relatedLabs)
+      logger.info(`Set page-related-labs attribute for ${docPage.asciidoc.doctitle} to ${docPage.asciidoc.attributes['page-related-labs']}`)
+    })
+  })
+}
+
+function findRelated(labPage, sourceCategoryList, sourceDeploymentType, logger) {
+  const targetAttributes = labPage.asciidoc.attributes
+  const pageCategories = targetAttributes['page-categories'];
+  if (!pageCategories) return null;
+  const targetCategoryList = pageCategories.split(',').map(c => c.trim());
+  const targetDeploymentType = getDeploymentType(targetAttributes)
+  const categoryMatch = hasMatchingCategory(sourceCategoryList, targetCategoryList)
+  if (categoryMatch && (!targetDeploymentType ||sourceDeploymentType === targetDeploymentType || targetDeploymentType === 'Docker')) {
+    return {
+      title: labPage.asciidoc.doctitle,
+      url: labPage.pub.url,
+    }
+  }
+  return null
+}
+
+function getDeploymentType (attributes) {
+  return attributes['env-kubernetes'] ? 'Kubernetes'
+    : attributes['env-linux'] ? 'Linux'
+      : attributes['env-docker'] ? 'Docker'
+        : attributes.cloud ? 'Redpanda Cloud' : ''
+}
+
+function hasMatchingCategory (sourcePageCategories, targetPageCategories) {
+  return sourcePageCategories.every((category) => targetPageCategories.includes(category))
+}

--- a/extensions/unlisted-pages.js
+++ b/extensions/unlisted-pages.js
@@ -6,6 +6,7 @@ module.exports.register = function ({ config }) {
       contentCatalog.getComponents().forEach(({ versions }) => {
         versions.forEach(({ name: component, version, navigation: nav, url: defaultUrl }) => {
           if (component === 'api') return;
+          if (!nav) return
           const navEntriesByUrl = getNavEntriesByUrl(nav)
           const unlistedPages = contentCatalog
             .findBy({ component, version, family: 'page' })

--- a/extensions/validate-attributes.js
+++ b/extensions/validate-attributes.js
@@ -1,0 +1,88 @@
+/* Example use in the playbook
+* antora:
+    extensions:
+ *    - require: ./extensions/validate-attributes.js
+*/
+
+'use strict';
+
+module.exports.register = function ({ config }) {
+  const logger = this.getLogger('attribute-validation-extension');
+
+  this.on('documentsConverted', async ({ contentCatalog, siteCatalog }) => {
+    // Retrieve valid categories and subcategories from site attributes defined in add-global-attributes.js.
+    const validCategories = siteCatalog.attributeFile['page-valid-categories'];
+    const categoryMap = createCategoryMap(validCategories);
+    const pages = contentCatalog.findBy({ family: 'page' });
+    pages.forEach((page) => {
+      let pageCategories = page.asciidoc.attributes['page-categories'];
+      if (!pageCategories) return;
+      let pageCategoryList = pageCategories.split(',').map(c => c.trim());
+      const validatedCategories = validateCategories(pageCategoryList, page.asciidoc.attributes['page-relative-src-path'], categoryMap, logger);
+      page.asciidoc.attributes['page-categories'] = validatedCategories
+      processEnvironmentAttributes(page, logger);
+    })
+  })
+}
+
+function processEnvironmentAttributes(page, logger) {
+  const envAttributes = ['env-kubernetes', 'env-linux', 'env-docker'];
+  envAttributes.forEach(envAttr => {
+    if (page.asciidoc.attributes[envAttr]) {
+      // If the env attribute exists, set a corresponding page- attribute for use in the UI
+      const pageEnvAttr = `page-${envAttr}`;
+      page.asciidoc.attributes[pageEnvAttr] = true;
+      logger.info(`Set '${pageEnvAttr}' for ${page.asciidoc.attributes['page-relative-src-path']}`);
+    }
+  });
+}
+
+function validateCategories(pageCategoryList, pageInfo, categoryMap, logger) {
+  let isValid = true;
+  let adjustedCategories = new Set(pageCategoryList);
+
+  pageCategoryList.forEach(category => {
+    // Check if the current category is a subcategory
+    if (categoryMap.subcategories.has(category)) {
+      // Retrieve the parent category for the current subcategory
+      const parentCategory = categoryMap.parentMap.get(category);
+
+      // Check if the parent category is not already in the pageCategoryList
+      if (!adjustedCategories.has(parentCategory)) {
+        // Add the parent category since it's missing
+        adjustedCategories.add(parentCategory);
+        logger.info(`Added missing parent category '${parentCategory}' for subcategory '${category}' in ${pageInfo}`);
+      }
+    }
+    // Check if the current category is not a valid category or subcategory
+    else if (!categoryMap.categories.has(category)) {
+      logger.warn(`Invalid category '${category}' in ${pageInfo}`);
+      adjustedCategories.delete(category)
+      isValid = false;
+    }
+  });
+
+  if (!isValid) {
+      logger.warn(`Invalid categories detected. For a list of valid categories, see https://github.com/redpanda-data/docs/tree/shared/modules/ROOT/partials/valid-categories.yml`);
+  }
+  return Array.from(adjustedCategories).join(', ');
+}
+
+function createCategoryMap(validCategories) {
+  const categoryMap = {
+    categories: new Set(),
+    subcategories: new Set(),
+    parentMap: new Map()
+  };
+
+  validCategories.forEach(categoryInfo => {
+    categoryMap.categories.add(categoryInfo.category);
+    if (categoryInfo.subcategories) {
+      categoryInfo.subcategories.forEach(subcat => {
+        categoryMap.subcategories.add(subcat.category);
+        categoryMap.parentMap.set(subcat.category, categoryInfo.category);
+      });
+    }
+  });
+  return categoryMap
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.1.5",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.1.5",
+      "version": "3.2.0",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.1.5",
+  "version": "3.2.0",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
Part of https://github.com/redpanda-data/documentation-private/issues/2259

This PR introduces enhancements to our documentation infrastructure, targeting the discoverability of Redpanda labs from related documentation and vice versa. By implementing a category validator and extensions that identify and store related documents and labs, we aim to create a more interconnected and user-friendly documentation experience.

- Category validator: A new validation extension ensures that all categories used within our documentation and lab exercises adhere to a predefined list of valid categories. This validation process is crucial for maintaining the consistency and relevance of the content, ensuring that users are guided to related materials that genuinely enhance their understanding and application of the material.

- Related docs and labs extensions: We've developed extensions that automatically identify related documentation pages and lab exercises based on shared categories and deployment types. This feature dynamically generates a list of related resources, which are then stored in a new page attribute for easy access and integration within the UI.