### PR TITLE
Fix Octokit major.minor version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "3.2.2",
       "license": "ISC",
       "dependencies": {
-        "@octokit/plugin-retry": "^4.1.3",
-        "@octokit/rest": "^19.0.7",
+        "@octokit/plugin-retry": "~4.1.3",
+        "@octokit/rest": "~19.0.7",
         "algoliasearch": "^4.17.0",
         "chalk": "4.1.2",
         "gulp": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "url": "git+https://github.com/redpanda-data/docs-extensions-and-macros"
   },
   "dependencies": {
-    "@octokit/plugin-retry": "^4.1.3",
-    "@octokit/rest": "^19.0.7",
+    "@octokit/plugin-retry": "~4.1.3",
+    "@octokit/rest": "~19.0.7",
     "algoliasearch": "^4.17.0",
     "chalk": "4.1.2",
     "gulp": "^4.0.2",


### PR DESCRIPTION
It seems that upstream minor versions of Octokit break our extension scripts. So doing `npm update` in the docs repos results in:

```

[10:22:38.830] FATAL (antora): No "exports" main defined in /Users/***/Documents/rp-docs/docs/node_modules/@octokit/request-error/package.json
Add the --stacktrace option to see the cause of the error.
```

This PR fixes the version of Octokit so that we only get patch updates.