### PR TITLE
Add product name and/or version to Algolia tags

### DIFF
--- a/extensions/algolia-indexer/generate-index.js
+++ b/extensions/algolia-indexer/generate-index.js
@@ -175,7 +175,7 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
       .replace(/\s+/g, ' ')
       .trim();
 
-    var tag = `${component.title}${version ? '-' + version : ''}`
+    var tag = `${component.title} ${version ? 'v' + version : ''}`
     var indexItem;
     const deployment = page.asciidoc?.attributes['env-kubernetes'] ? 'Kubernetes' : page.asciidoc?.attributes['env-linux'] ? 'Linux' : page.asciidoc?.attributes['env-docker'] ? 'Docker' : page.asciidoc?.attributes['page-cloud'] ? 'Redpanda Cloud' : ''
 
@@ -198,7 +198,7 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
       indexItem.product = component.title;
       indexItem.breadcrumbs = breadcrumbs;
       indexItem.type = 'Doc';
-      indexItem._tags = [tag, 'docs'];
+      indexItem._tags = [tag];
     } else {
       indexItem.deployment = deployment;
       indexItem.type = 'Lab';

--- a/extensions/algolia-indexer/generate-index.js
+++ b/extensions/algolia-indexer/generate-index.js
@@ -77,7 +77,7 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
 
     // capture the component name and version
     const cname = component.name
-    const version = page.src.version
+    const version = page.src.prerelease ? page.src.displayVersion : page.src.version;
 
     // handle the page keywords
     const kw = root.querySelector('meta[name=keywords]')

--- a/extensions/algolia-indexer/index.js
+++ b/extensions/algolia-indexer/index.js
@@ -114,7 +114,7 @@ function register({
     }
 
     for (const [objectID, obj] of existingObjectsMap) {
-      if ((obj.type === 'Doc' && !obj._tags.includes('apis')) || (!obj.type) || (obj.type === 'Lab' && !obj.interactive)) {
+      if ((obj.type === 'Doc' && !obj.objectID.includes('/api/')) || (!obj.type) || (obj.type === 'Lab' && !obj.interactive)) {
         objectsToDelete.push(objectID)
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "~4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
Part of https://github.com/redpanda-data/documentation-private/issues/2294

Our detached Algolia search relies on tags to allow users to select/deselect filters. To allow users to filter by product version, this PR adds the product name and version to the `_tags` field of all Algolia index records for docs.