### PR TITLE
Add redirect modifier

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -180,6 +180,27 @@ antora:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/add-global-attributes'
 ```
 
+=== Modify redirects file
+
+This extension removes redundant redirects from the Netlify redirects file. The need for this extension arises from an issue where the use of the `indexify` feature in Antora, combined with page aliases, can inadvertently create redirect loops or redundant redirects where the source and target URLs are identical.
+
+The issue is https://antora.zulipchat.com/#narrow/stream/282400-users/topic/Redirect.20Loop.20Issue.20with.20Page.20Renaming.20and.20Indexify/near/433691700[recognized as a bug] within Antora's redirect producer, which does not currently
+check if the source and target URLs are the same before creating a redirect.
+
+The purpose of this script is to scan the `_redirects` file and remove any entries that point
+a URL to itself, which not only prevents redirect loops but also optimizes the redirect process
+by eliminating unnecessary entries. This cleanup helps ensure that the redirects file only contains valid and useful redirection rules.
+
+By integrating this script into the Antora pipeline, we ensure that each build's output is optimized and free from potential issues related to improper redirects, enhancing both site performance and user experience.
+
+==== Registration example
+
+```yaml
+antora:
+  extensions:
+  - '@redpanda-data/docs-extensions-and-macros/extensions/modify-redirects'
+```
+
 === Replace attributes in attachments
 
 This extension replaces AsciiDoc attribute placeholders with their respective values in attachment files, such as CSS, HTML, and YAML.

--- a/extensions/modify-redirects.js
+++ b/extensions/modify-redirects.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function redirectModifier(files, outputDir, logger) {
+  files.forEach((file) => {
+    const filePath = path.join(outputDir, file);
+    if (!fs.existsSync(filePath)) return
+    let content = fs.readFileSync(filePath, 'utf8');
+    const lines = content.split('\n');
+
+    // Filter out redirects that point to themselves
+    const modifiedLines = lines.filter((line) => {
+      const parts = line.split(' ');
+      if (parts[0] == parts[1]) logger.info(`Removed redirect that points to itself: ${line}`)
+      return parts[0] !== parts[1]; // Ensure the source and target are not the same
+    });
+
+    // Join the array back into a string and write it back to the file
+    const modifiedContent = modifiedLines.join('\n');
+    fs.writeFileSync(filePath, modifiedContent, 'utf8');
+    logger.info(`Processed and updated redirects in ${filePath}`);
+  })
+}
+
+module.exports.register = function ({ config }) {
+  const logger = this.getLogger('redirects-produced');
+  this.on('sitePublished', async ({ publications }) => {
+    publications.forEach(publication => {
+      const outputDir = publication.resolvedPath;
+      const redirectFile = ['_redirects'];
+      redirectModifier(redirectFile, outputDir, logger);
+    });
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.2.4",
+      "version": "3.2.5",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "~4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",
@@ -35,6 +35,7 @@
     "./extensions/validate-attributes": "./extensions/validate-attributes.js",
     "./extensions/find-related-docs": "./extensions/find-related-docs.js",
     "./extensions/find-related-labs": "./extensions/find-related-labs.js",
+    "./extensions/modify-redirects": "./extensions/modify-redirects.js",
     "./extensions/algolia-indexer/index": "./extensions/algolia-indexer/index.js",
     "./extensions/aggregate-terms": "./extensions/aggregate-terms.js",
     "./macros/glossary": "./macros/glossary.js",


### PR DESCRIPTION
Adds an Antora extension that removes redirects that point to themselves to avoid redirect loops. This was recognized as a bug in Antora in a [conversation](https://antora.zulipchat.com/#narrow/stream/282400-users/topic/Redirect.20Loop.20Issue.20with.20Page.20Renaming.20and.20Indexify/near/433691700) with the Antora maintainer.

Without this extension, we can get xref validation errors when we rename existing pages to `index.adoc`. See the conversation for more details:

> Jake Cahill: I'm currently facing a challenge with our Antora setup that I hope some of you might help me address. We've recently renamed a page from modules/manage/security/authorization.adoc to modules/manage/security/authorization/index.adoc. Additionally, we are using the indexify transformation in our playbook. The problem arises with the use of page aliases. Normally, I would add a page alias like manage:security/authorization.adoc to handle old links. However, due to `indexify, this is causing a redirect loop. On the other hand, omitting the alias leads to "xref not found" errors for links that point to manage/security/authorization. Has anyone else encountered this issue? How have you managed to resolve conflicts between indexify and page aliasing, especially in cases where it results in redirect loops or broken cross-references? Any insights or suggestions would be greatly appreciated!

> mojavelinux: This may be something Antora needs to check for. If the source and target URL end up being the same, there's no need for Antora to add a redirect for that alias since it will already resolve. But the alias will still be used for resolving the xref. I vaguely remembering looking into something like this. Perhaps this is another case? ...yep, I confirmed that the redirect producer does not check whether the source and target URL are the same. I just assumed they never would be, but this is a case when they are. This will probably need to be filed as an issue. However, it's not something I have time to work on right now, so a patch would be needed for a near-term fix. Otherwise, you could solve it using an Antora extension by reworking the contents of the redirect file before it is written to the output (or in a postprocessing step in your own publishing pipeline).