### PR TITLE
Add support for custom glossary link text

### DIFF
--- a/macros/glossary.js
+++ b/macros/glossary.js
@@ -91,9 +91,10 @@ module.exports.register = function (registry, config = {}) {
       self.named('glossterm')
       //Specifying the regexp allows spaces in the term.
       self.$option('regexp', /glossterm:([^[]+)\[(|.*?[^\\])\]/)
-      self.positionalAttributes(['definition'])
+      self.positionalAttributes(['definition', 'customText']);
       self.process(function (parent, target, attributes) {
         const term = attributes.term || target
+        const customText = attributes.customText || term;
         const document = parent.document
         const context = vfs.getContext()
         const customLinkCandidate = context.gloss.find(candidate => 'link' in candidate && candidate.term === term);
@@ -136,10 +137,10 @@ module.exports.register = function (registry, config = {}) {
         const termExistsInContext = context.gloss.some((candidate) => candidate.term === term);
         if ((termExistsInContext && links) || (links && customLink)) {
           inline = customLink
-            ? self.createInline(parent, 'anchor', target, { type: 'link', target: customLink, attributes: { ...attrs, window: '_blank', rel: 'noopener noreferrer' } })
-            : self.createInline(parent, 'anchor', target, { type: 'xref', target: `${glossaryPage}#${termId(term)}`, reftext: target, attributes: attrs })
+            ? self.createInline(parent, 'anchor', customText, { type: 'link', target: customLink, attributes: { ...attrs, window: '_blank', rel: 'noopener noreferrer' } })
+            : self.createInline(parent, 'anchor', customText, { type: 'xref', target: `${glossaryPage}#${termId(term)}`, reftext: customText, attributes: attrs })
         } else {
-          inline = self.createInline(parent, 'quoted', target, { attributes: attrs })
+          inline = self.createInline(parent, 'quoted', customText, { attributes: attrs })
         }
         if (tooltip) {
           const a = inline.convert()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
@@ -32,12 +32,7 @@ glossterm:<term-name>[,<custom-link-text>]
 
 Here, replace `<custom-link-text>` with your text that will appear as the link. For example:
 
-[,asciidoc]
-----
-glossterm:seed server[,seed servers]
-----
-
-This will display "seed servers" as the link text but will still link to the "seed server" term definition.
+glossterm:test term[,This link text is custom.]
 
 The `hover-text` attribute is read from the term file and used to add hover text to the term.
 

--- a/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
@@ -23,6 +23,22 @@ glossterm:<term-name>[]
 
 Replace `<term-name>` with the value of the `term-name` attribute in a term file.
 
+To add custom link text for a term, which can be useful for displaying plurals or context-specific variations of the term without changing the term reference, use this syntax:
+
+[,asciidoc]
+----
+glossterm:<term-name>[,<custom-link-text>]
+----
+
+Here, replace `<custom-link-text>` with your text that will appear as the link. For example:
+
+[,asciidoc]
+----
+glossterm:seed server[,seed servers]
+----
+
+This will display "seed servers" as the link text but will still link to the "seed server" term definition.
+
 The `hover-text` attribute is read from the term file and used to add hover text to the term.
 
 The rules for whether a link to the glossary entry is added to the term, depend on what content is available on the term page:


### PR DESCRIPTION
Example: https://deploy-preview-38--docs-extensions-and-macros.netlify.app/preview/test/#:~:text=This%20link%20text%20is%20custom.