### PR TITLE
Get latest Helm chart version

### DIFF
--- a/extensions/version-fetcher/get-latest-console-version.js
+++ b/extensions/version-fetcher/get-latest-console-version.js
@@ -18,11 +18,11 @@ const github = new OctokitWithRetries(githubOptions);
 
 module.exports = async () => {
   try {
-    // Fetch the latest 10 releases
     const releases = await github.rest.repos.listReleases({
       owner,
       repo,
-      per_page: 10,
+      page: 1,
+      per_page: 50
     });
 
     // Filter valid semver tags and sort them

--- a/extensions/version-fetcher/get-latest-redpanda-helm-version.js
+++ b/extensions/version-fetcher/get-latest-redpanda-helm-version.js
@@ -1,0 +1,33 @@
+const { Octokit } = require("@octokit/rest");
+const { retry } = require("@octokit/plugin-retry");
+const yaml = require('js-yaml');
+const OctokitWithRetries = Octokit.plugin(retry);
+
+const githubOptions = {
+  userAgent: 'Redpanda Docs',
+  baseUrl: 'https://api.github.com',
+  auth: process.env.REDPANDA_GITHUB_TOKEN
+};
+
+const github = new OctokitWithRetries(githubOptions);
+const owner = 'redpanda-data';
+const repo = 'helm-charts';
+const path = 'charts/redpanda/Chart.yaml';
+
+module.exports = async () => {
+  try {
+    const response = await github.repos.getContent({
+      owner: owner,
+      repo: repo,
+      path: path,
+    });
+
+    const contentBase64 = response.data.content;
+    const contentDecoded = Buffer.from(contentBase64, 'base64').toString('utf8');
+    const chartYaml = yaml.load(contentDecoded);
+    return chartYaml.version;
+  } catch (error) {
+    console.error('Failed to fetch chart version:', error.message);
+    return null
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.2.8",
+      "version": "3.2.9",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "~4.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.6",
+  "version": "3.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.2.6",
+      "version": "3.2.8",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "~4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
@@ -76,6 +76,8 @@ The `version fetcher` extension gets the latest version of Redpanda and Redpanda
 - `\{full-version}`: {full-version}
 - `\{latest-release-commit}`: {latest-release-commit}
 - `\{latest-console-version}`: {latest-console-version}
+- `\{latest-operator-version}`: {latest-operator-version}
+- `\{latest-redpanda-helm-chart-version}`: {latest-redpanda-helm-chart-version}
 
 == Attachments
 


### PR DESCRIPTION
As part of https://github.com/redpanda-data/documentation-private/issues/2403, this PR adds functionality to save the latest version of the Redpanda Helm chart to attributes in the latest docs for Redpanda.

It also fixes a bug where if the `latest` release tag on GitHub was set to an older patch release, the latest Redpanda version was set to that. Now, we sort the versions to make sure that we always return the actual latest version.

Note: I am seeing strange behavior in the GitHub API where 24.1.1 doesn't appear in https://api.github.com/repos/redpanda-data/redpanda/releases?per_page=1000 