### PR TITLE
Allow writers to define a later version

### DIFF
--- a/extensions/unpublish-pages.js
+++ b/extensions/unpublish-pages.js
@@ -1,0 +1,9 @@
+module.exports.register = function () {
+  this.on('documentsConverted', ({ contentCatalog }) => {
+    contentCatalog.getPages((page) => page.out).forEach((page) => {
+      if (page.asciidoc?.attributes['page-unpublish'] != null || page.asciidoc?.attributes['page-layout'] === 'api-partial') {
+        delete page.out
+      }
+    })
+  })
+}

--- a/extensions/version-fetcher/get-latest-console-version.js
+++ b/extensions/version-fetcher/get-latest-console-version.js
@@ -18,11 +18,11 @@ const github = new OctokitWithRetries(githubOptions);
 
 module.exports = async () => {
   try {
-    // Fetch the latest 10 releases
     const releases = await github.rest.repos.listReleases({
       owner,
       repo,
-      per_page: 10,
+      page: 1,
+      per_page: 50
     });
 
     // Filter valid semver tags and sort them

--- a/extensions/version-fetcher/get-latest-redpanda-helm-version.js
+++ b/extensions/version-fetcher/get-latest-redpanda-helm-version.js
@@ -1,0 +1,33 @@
+const { Octokit } = require("@octokit/rest");
+const { retry } = require("@octokit/plugin-retry");
+const yaml = require('js-yaml');
+const OctokitWithRetries = Octokit.plugin(retry);
+
+const githubOptions = {
+  userAgent: 'Redpanda Docs',
+  baseUrl: 'https://api.github.com',
+  auth: process.env.REDPANDA_GITHUB_TOKEN
+};
+
+const github = new OctokitWithRetries(githubOptions);
+const owner = 'redpanda-data';
+const repo = 'helm-charts';
+const path = 'charts/redpanda/Chart.yaml';
+
+module.exports = async () => {
+  try {
+    const response = await github.repos.getContent({
+      owner: owner,
+      repo: repo,
+      path: path,
+    });
+
+    const contentBase64 = response.data.content;
+    const contentDecoded = Buffer.from(contentBase64, 'base64').toString('utf8');
+    const chartYaml = yaml.load(contentDecoded);
+    return chartYaml.version;
+  } catch (error) {
+    console.error('Failed to fetch chart version:', error.message);
+    return null
+  }
+};

--- a/extensions/version-fetcher/get-latest-redpanda-version.js
+++ b/extensions/version-fetcher/get-latest-redpanda-version.js
@@ -33,7 +33,6 @@ module.exports = async () => {
       .filter(tag => semver.valid(tag))
       // Sort in descending order to get the highest version first
       .sort(semver.rcompare);
-    console.log(sortedReleases)
 
     if (sortedReleases.length > 0) {
       const latestRedpandaReleaseVersion = sortedReleases[0];

--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -1,13 +1,14 @@
-const GetLatestRedpandaVersion = require('./get-latest-redpanda-version');
-const GetLatestConsoleVersion = require('./get-latest-console-version');
-const GetLatestOperatorVersion = require('./get-latest-operator-version');
-const GetLatestHelmChartVersion = require('./get-latest-redpanda-helm-version');
-const chalk = require('chalk');
+const GetLatestRedpandaVersion = require('./get-latest-redpanda-version')
+const GetLatestConsoleVersion = require('./get-latest-console-version')
+const GetLatestOperatorVersion = require('./get-latest-operator-version')
+const GetLatestHelmChartVersion = require('./get-latest-redpanda-helm-version')
+const chalk = require('chalk')
+const semver = require('semver')
 
 module.exports.register = function ({ config }) {
-  const logger = this.getLogger('set-latest-version-extension');
+  const logger = this.getLogger('set-latest-version-extension')
   if (!process.env.REDPANDA_GITHUB_TOKEN) {
-    logger.warn('REDPANDA_GITHUB_TOKEN environment variable not set. Attempting unauthenticated request.');
+    logger.warn('REDPANDA_GITHUB_TOKEN environment variable not set. Attempting unauthenticated request.')
   }
 
   this.on('contentClassified', async ({ contentCatalog }) => {
@@ -17,54 +18,49 @@ module.exports.register = function ({ config }) {
         GetLatestConsoleVersion(),
         GetLatestOperatorVersion(),
         GetLatestHelmChartVersion()
-      ]);
+      ])
 
-      // Extracting results with fallbacks if promises were rejected
-      const LatestRedpandaVersion = results[0].status === 'fulfilled' ? results[0].value : null;
-      const LatestConsoleVersion = results[1].status === 'fulfilled' ? results[1].value : null;
-      const LatestOperatorVersion = results[2].status === 'fulfilled' ? results[2].value : null;
-      const LatestHelmChartVersion = results[3].status === 'fulfilled' ? results[3].value : null;
+      const LatestRedpandaVersion = results[0].status === 'fulfilled' ? results[0].value : null
+      const LatestConsoleVersion = results[1].status === 'fulfilled' ? results[1].value : null
+      const LatestOperatorVersion = results[2].status === 'fulfilled' ? results[2].value : null
+      const LatestHelmChartVersion = results[3].status === 'fulfilled' ? results[3].value : null
 
-      const components = await contentCatalog.getComponents();
+      const components = await contentCatalog.getComponents()
       components.forEach(component => {
         component.versions.forEach(({ name, version, asciidoc }) => {
           if (LatestConsoleVersion) {
-            asciidoc.attributes['latest-console-version'] = LatestConsoleVersion;
-            logger.info(`Set Redpanda Console version to ${LatestConsoleVersion} in ${name} ${version}`);
+            asciidoc.attributes['latest-console-version'] = `${LatestConsoleVersion}@`
+            logger.info(`Set Redpanda Console version to ${LatestConsoleVersion} in ${name} ${version}`)
           }
-        });
+        })
 
         if (!component.latest.asciidoc) {
-          component.latest.asciidoc = { attributes: {} };
+          component.latest.asciidoc = { attributes: {} }
         }
 
-        // Handle each version setting with appropriate logging
-        if (LatestRedpandaVersion) {
-          component.latest.asciidoc.attributes['full-version'] = LatestRedpandaVersion[0];
-          component.latest.asciidoc.attributes['latest-release-commit'] = LatestRedpandaVersion[1];
-          logger.info(`Set the latest Redpanda version to ${LatestRedpandaVersion[0]} ${LatestRedpandaVersion[1]}`);
-        } else {
-          logger.warn("Failed to get the latest Redpanda version - using defaults");
+        if (LatestRedpandaVersion && semver.valid(LatestRedpandaVersion[0])) {
+          let currentVersion = component.latest.asciidoc.attributes['full-version'] || '0.0.0'
+          if (semver.gt(LatestRedpandaVersion[0], currentVersion)) {
+            component.latest.asciidoc.attributes['full-version'] = `${LatestRedpandaVersion[0]}@`
+            component.latest.asciidoc.attributes['latest-release-commit'] = `${LatestRedpandaVersion[1]}@`
+            logger.info(`Updated to latest Redpanda version: ${LatestRedpandaVersion[0]} with commit: ${LatestRedpandaVersion[1]}`)
+          }
         }
 
         if (LatestOperatorVersion) {
-          component.latest.asciidoc.attributes['latest-operator-version'] = LatestOperatorVersion;
-          logger.info(`Set the latest Redpanda Operator version to ${LatestOperatorVersion}`);
-        } else {
-          logger.warn("Failed to get the latest Operator version from GitHub - using default");
+          component.latest.asciidoc.attributes['latest-operator-version'] = `${LatestOperatorVersion}@`
+          logger.info(`Updated to latest Redpanda Operator version: ${LatestOperatorVersion}`)
         }
 
         if (LatestHelmChartVersion) {
-          component.latest.asciidoc.attributes['latest-redpanda-helm-chart-version'] = LatestHelmChartVersion;
-          logger.info(`Set the latest Redpanda Helm chart version to ${LatestHelmChartVersion}`);
-        } else {
-          logger.warn("Failed to get the latest Helm Chart version - using default");
+          component.latest.asciidoc.attributes['latest-redpanda-helm-chart-version'] = `${LatestHelmChartVersion}@`
+          logger.info(`Updated to latest Redpanda Helm chart version: ${LatestHelmChartVersion}`)
         }
-      });
+      })
 
-      console.log(`${chalk.green('Updated Redpanda documentation versions successfully.')}`);
+      console.log(`${chalk.green('Updated Redpanda documentation versions successfully.')}`)
     } catch (error) {
-      logger.error(`Error updating versions: ${error}`);
+      logger.error(`Error updating versions: ${error}`)
     }
-  });
-};
+  })
+}

--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -6,7 +6,7 @@ const chalk = require('chalk')
 const semver = require('semver')
 
 module.exports.register = function ({ config }) {
-  const logger = this.getLogger('set-latest-version-extension')
+  const logger = this.getLogger('set-latest-version-extension');
   if (!process.env.REDPANDA_GITHUB_TOKEN) {
     logger.warn('REDPANDA_GITHUB_TOKEN environment variable not set. Attempting unauthenticated request.')
   }

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -27,6 +27,7 @@ antora:
   - './extensions/algolia-indexer/index'
   - require: './extensions/unlisted-pages'
   - require: './extensions/replace-attributes-in-attachments'
+  - require: './extensions/unpublish-pages'
   - require: './extensions/validate-attributes'
   - require: './extensions/find-related-docs'
   - require: './extensions/find-related-labs'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.2.8",
+      "version": "3.2.9",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "~4.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.6",
+  "version": "3.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.2.6",
+      "version": "3.2.8",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "~4.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.9",
+  "version": "3.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.2.9",
+      "version": "3.2.10",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "~4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.9",
+  "version": "3.2.10",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "./extensions/version-fetcher/set-latest-version": "./extensions/version-fetcher/set-latest-version.js",
     "./extensions/validate-attributes": "./extensions/validate-attributes.js",
     "./extensions/find-related-docs": "./extensions/find-related-docs.js",
+    "./extensions/unpublish-pages": "./extensions/unpublish-pages.js",
     "./extensions/find-related-labs": "./extensions/find-related-labs.js",
     "./extensions/modify-redirects": "./extensions/produce-redirects.js",
     "./extensions/algolia-indexer/index": "./extensions/algolia-indexer/index.js",

--- a/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
@@ -76,6 +76,8 @@ The `version fetcher` extension gets the latest version of Redpanda and Redpanda
 - `\{full-version}`: {full-version}
 - `\{latest-release-commit}`: {latest-release-commit}
 - `\{latest-console-version}`: {latest-console-version}
+- `\{latest-operator-version}`: {latest-operator-version}
+- `\{latest-redpanda-helm-chart-version}`: {latest-redpanda-helm-chart-version}
 
 == Attachments
 

--- a/preview/extensions-and-macros/modules/ROOT/pages/unpublish.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/pages/unpublish.adoc
@@ -1,0 +1,2 @@
+= This page will never be published
+:page-unpublish:


### PR DESCRIPTION
Since the GitHub API does not currently return version 24.1.1, we now support overwriting the version returned from GitHub with the one defined in the `full-version` attribute if that version is higher.