### PR TITLE
Return the latest version of Redpanda

### DIFF
--- a/extensions/version-fetcher/get-latest-redpanda-version.js
+++ b/extensions/version-fetcher/get-latest-redpanda-version.js
@@ -33,7 +33,6 @@ module.exports = async () => {
       .filter(tag => semver.valid(tag))
       // Sort in descending order to get the highest version first
       .sort(semver.rcompare);
-    console.log(sortedReleases)
 
     if (sortedReleases.length > 0) {
       const latestRedpandaReleaseVersion = sortedReleases[0];

--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -1,13 +1,14 @@
-const GetLatestRedpandaVersion = require('./get-latest-redpanda-version');
-const GetLatestConsoleVersion = require('./get-latest-console-version');
-const GetLatestOperatorVersion = require('./get-latest-operator-version');
-const GetLatestHelmChartVersion = require('./get-latest-redpanda-helm-version');
-const chalk = require('chalk');
+const GetLatestRedpandaVersion = require('./get-latest-redpanda-version')
+const GetLatestConsoleVersion = require('./get-latest-console-version')
+const GetLatestOperatorVersion = require('./get-latest-operator-version')
+const GetLatestHelmChartVersion = require('./get-latest-redpanda-helm-version')
+const chalk = require('chalk')
+const semver = require('semver')
 
 module.exports.register = function ({ config }) {
-  const logger = this.getLogger('set-latest-version-extension');
+  const logger = this.getLogger('set-latest-version-extension')
   if (!process.env.REDPANDA_GITHUB_TOKEN) {
-    logger.warn('REDPANDA_GITHUB_TOKEN environment variable not set. Attempting unauthenticated request.');
+    logger.warn('REDPANDA_GITHUB_TOKEN environment variable not set. Attempting unauthenticated request.')
   }
 
   this.on('contentClassified', async ({ contentCatalog }) => {
@@ -17,54 +18,49 @@ module.exports.register = function ({ config }) {
         GetLatestConsoleVersion(),
         GetLatestOperatorVersion(),
         GetLatestHelmChartVersion()
-      ]);
+      ])
 
-      // Extracting results with fallbacks if promises were rejected
-      const LatestRedpandaVersion = results[0].status === 'fulfilled' ? results[0].value : null;
-      const LatestConsoleVersion = results[1].status === 'fulfilled' ? results[1].value : null;
-      const LatestOperatorVersion = results[2].status === 'fulfilled' ? results[2].value : null;
-      const LatestHelmChartVersion = results[3].status === 'fulfilled' ? results[3].value : null;
+      const LatestRedpandaVersion = results[0].status === 'fulfilled' ? results[0].value : null
+      const LatestConsoleVersion = results[1].status === 'fulfilled' ? results[1].value : null
+      const LatestOperatorVersion = results[2].status === 'fulfilled' ? results[2].value : null
+      const LatestHelmChartVersion = results[3].status === 'fulfilled' ? results[3].value : null
 
-      const components = await contentCatalog.getComponents();
+      const components = await contentCatalog.getComponents()
       components.forEach(component => {
         component.versions.forEach(({ name, version, asciidoc }) => {
           if (LatestConsoleVersion) {
-            asciidoc.attributes['latest-console-version'] = LatestConsoleVersion;
-            logger.info(`Set Redpanda Console version to ${LatestConsoleVersion} in ${name} ${version}`);
+            asciidoc.attributes['latest-console-version'] = `${LatestConsoleVersion}@`
+            logger.info(`Set Redpanda Console version to ${LatestConsoleVersion} in ${name} ${version}`)
           }
-        });
+        })
 
         if (!component.latest.asciidoc) {
-          component.latest.asciidoc = { attributes: {} };
+          component.latest.asciidoc = { attributes: {} }
         }
 
-        // Handle each version setting with appropriate logging
-        if (LatestRedpandaVersion) {
-          component.latest.asciidoc.attributes['full-version'] = LatestRedpandaVersion[0];
-          component.latest.asciidoc.attributes['latest-release-commit'] = LatestRedpandaVersion[1];
-          logger.info(`Set the latest Redpanda version to ${LatestRedpandaVersion[0]} ${LatestRedpandaVersion[1]}`);
-        } else {
-          logger.warn("Failed to get the latest Redpanda version - using defaults");
+        if (LatestRedpandaVersion && semver.valid(LatestRedpandaVersion[0])) {
+          let currentVersion = component.latest.asciidoc.attributes['full-version'] || '0.0.0'
+          if (semver.gt(LatestRedpandaVersion[0], currentVersion)) {
+            component.latest.asciidoc.attributes['full-version'] = `${LatestRedpandaVersion[0]}@`
+            component.latest.asciidoc.attributes['latest-release-commit'] = `${LatestRedpandaVersion[1]}@`
+            logger.info(`Updated to latest Redpanda version: ${LatestRedpandaVersion[0]} with commit: ${LatestRedpandaVersion[1]}`)
+          }
         }
 
         if (LatestOperatorVersion) {
-          component.latest.asciidoc.attributes['latest-operator-version'] = LatestOperatorVersion;
-          logger.info(`Set the latest Redpanda Operator version to ${LatestOperatorVersion}`);
-        } else {
-          logger.warn("Failed to get the latest Operator version from GitHub - using default");
+          component.latest.asciidoc.attributes['latest-operator-version'] = `${LatestOperatorVersion}@`
+          logger.info(`Updated to latest Redpanda Operator version: ${LatestOperatorVersion}`)
         }
 
         if (LatestHelmChartVersion) {
-          component.latest.asciidoc.attributes['latest-redpanda-helm-chart-version'] = LatestHelmChartVersion;
-          logger.info(`Set the latest Redpanda Helm chart version to ${LatestHelmChartVersion}`);
-        } else {
-          logger.warn("Failed to get the latest Helm Chart version - using default");
+          component.latest.asciidoc.attributes['latest-redpanda-helm-chart-version'] = `${LatestHelmChartVersion}@`
+          logger.info(`Updated to latest Redpanda Helm chart version: ${LatestHelmChartVersion}`)
         }
-      });
+      })
 
-      console.log(`${chalk.green('Updated Redpanda documentation versions successfully.')}`);
+      console.log(`${chalk.green('Updated Redpanda documentation versions successfully.')}`)
     } catch (error) {
-      logger.error(`Error updating versions: ${error}`);
+      logger.error(`Error updating versions: ${error}`)
     }
-  });
-};
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.9",
+  "version": "3.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.2.9",
+      "version": "3.2.10",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "~4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.9",
+  "version": "3.2.10",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
Since the GitHub API does not currently return version 24.1.1, we now support overwriting the version returned from GitHub with the one defined in the full-version attribute if that version is higher.