### PR TITLE
Make sure to exclude RC releases

### DIFF
--- a/extensions/version-fetcher/get-latest-redpanda-version.js
+++ b/extensions/version-fetcher/get-latest-redpanda-version.js
@@ -30,7 +30,7 @@ module.exports = async () => {
     // Filter valid semver tags and sort them to find the highest version
     const sortedReleases = releases.data
       .map(release => release.tag_name.replace(/^v/, ''))
-      .filter(tag => semver.valid(tag))
+      .filter(tag => semver.valid(tag) && !tag.match(/rc-\d+$/))  // Exclude 'rc-{number}' suffixes
       // Sort in descending order to get the highest version first
       .sort(semver.rcompare);
 

--- a/extensions/version-fetcher/get-latest-redpanda-version.js
+++ b/extensions/version-fetcher/get-latest-redpanda-version.js
@@ -30,7 +30,7 @@ module.exports = async () => {
     // Filter valid semver tags and sort them to find the highest version
     const sortedReleases = releases.data
       .map(release => release.tag_name.replace(/^v/, ''))
-      .filter(tag => semver.valid(tag) && !tag.match(/rc-\d+$/))  // Exclude 'rc-{number}' suffixes
+      .filter(tag => semver.valid(tag) && !tag.match(/rc\d+$/))  // Exclude 'rc-{number}' suffixes
       // Sort in descending order to get the highest version first
       .sort(semver.rcompare);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.11",
+  "version": "3.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.2.11",
+      "version": "3.2.12",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "~4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.2.11",
+  "version": "3.2.12",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/preview/extensions-and-macros/antora.yml
+++ b/preview/extensions-and-macros/antora.yml
@@ -8,5 +8,5 @@ asciidoc:
   attributes:
     replace-attributes-in-attachments: true
     test-attribute: This attribute was replaced by the `replace-attributes-in-attachments` extension.
-    full-version: 'This should get replaced'
+    full-version: 23.2.1
     latest-release-commit: 'This should get replaced'


### PR DESCRIPTION
When you call `ListReleases` with an authentication token, the results include RC (release candidate) versions. We now exclude those.

[Test results](https://deploy-preview-44--docs-extensions-and-macros.netlify.app/preview/test/#latest-versions)