### PR TITLE
Check for existence of attributes to avoid errors

### DIFF
--- a/extensions/unlisted-pages.js
+++ b/extensions/unlisted-pages.js
@@ -16,7 +16,7 @@ module.exports.register = function ({ config }) {
         const unlistedPages = contentCatalog
           .findBy({ component, version, family: 'page' })
           .reduce((collector, page) => {
-            if (siteCatalog.unpublishedPages.includes(page.pub.url)) {
+            if (siteCatalog.unpublishedPages?.includes(page.pub.url)) {
               logger.info({ file: page.src, source: page.src.origin }, 'removing unpublished page from nav tree');
               removePageFromNav(nav, page.pub.url); // Remove the page from navigationCatalog
               return collector; // Skip adding this page to the collector

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "~4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
Without the `unpublish-pages` extension, the `siteCatalog.unpublishedPages` never gets set, leading to `FATAL (antora): Cannot read properties of undefined (reading 'includes')`.

This PR adds a check to avoid this error in case some playbooks don't include the `unpublish-pages` extension.