### PR TITLE
improve error handling in version fetcher

### DIFF
--- a/extensions/version-fetcher/get-latest-redpanda-version.js
+++ b/extensions/version-fetcher/get-latest-redpanda-version.js
@@ -58,10 +58,10 @@ module.exports = async () => {
       }
 
       return {
-        latestRedpandaRelease: {
+        latestRedpandaRelease: latestRedpandaReleaseVersion ? {
           version: latestRedpandaReleaseVersion,
           commitHash: latestRedpandaReleaseCommitHash.substring(0, 7)
-        },
+        } : null ,
         latestRcRelease: latestRcReleaseVersion ? {
           version: latestRcReleaseVersion,
           commitHash: latestRcReleaseCommitHash.substring(0, 7)

--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -39,7 +39,7 @@ module.exports.register = function ({ config }) {
             asciidoc.attributes['latest-connect-version'] = `${LatestConnectVersion}@`
             logger.info(`Set Redpanda Connect version to ${LatestConnectVersion} in ${name} ${version}`)
           }
-          if (LatestRedpandaVersion && LatestRedpandaVersion.latestRcRelease) {
+          if (LatestRedpandaVersion && LatestRedpandaVersion.latestRcRelease && LatestRedpandaVersion.latestRcRelease.version) {
             asciidoc.attributes['redpanda-beta-version'] = `${LatestRedpandaVersion.latestRcRelease.version}@`
             asciidoc.attributes['redpanda-beta-commit'] = `${LatestRedpandaVersion.latestRcRelease.commitHash}@`
             logger.info(`Updated to latest Redpanda RC version: ${LatestRedpandaVersion.latestRcRelease.version} with commit: ${LatestRedpandaVersion.latestRcRelease.commitHash}`)
@@ -50,7 +50,7 @@ module.exports.register = function ({ config }) {
           component.latest.asciidoc = { attributes: {} }
         }
 
-        if (LatestRedpandaVersion && semver.valid(LatestRedpandaVersion.latestRedpandaRelease.version)) {
+        if (LatestRedpandaVersion && LatestRedpandaVersion.latestRedpandaRelease && semver.valid(LatestRedpandaVersion.latestRedpandaRelease.version)) {
           let currentVersion = component.latest.asciidoc.attributes['full-version'] || '0.0.0'
           if (semver.gt(LatestRedpandaVersion.latestRedpandaRelease.version, currentVersion)) {
             component.latest.asciidoc.attributes['full-version'] = `${LatestRedpandaVersion.latestRedpandaRelease.version}@`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.4.2",
+      "version": "3.4.3",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "~4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
If we get rate limited (for local deploys), we currently get this error: `[18:38:36.088] ERROR (set-latest-version-extension): Error updating versions: TypeError: Cannot read properties of null (reading 'version')`. This PR adds proper error handling to avoid errors where the versions can't be fetched.