### PR TITLE
Move enterprise support definitions to antora.yaml file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "~4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
We used to define enterprise support in the `enterprise` attribute of the connector reference doc. But the autogenerated docs don't include this data in the templates. So we are moving the list of enterprise connectors to the [`antora.yaml` file](https://github.com/redpanda-data/rp-connect-docs/pull/14) with the certified connectors list.