### PR TITLE
Add descriptions of labs to related-labs object

### DIFF
--- a/extensions/find-related-labs.js
+++ b/extensions/find-related-labs.js
@@ -35,6 +35,7 @@ function findRelated(labPage, sourceCategoryList, sourceDeploymentType, logger) 
     return {
       title: labPage.asciidoc.doctitle,
       url: labPage.pub.url,
+      description: labPage.asciidoc.attributes.description,
     }
   }
   return null

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "~4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
Adds lab descriptions to the `related-labs` object to support the change in https://github.com/redpanda-data/docs-ui/pull/205