### PR TITLE
Use component titles for all tags

### DIFF
--- a/extensions/algolia-indexer/generate-index.js
+++ b/extensions/algolia-indexer/generate-index.js
@@ -203,7 +203,7 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
       indexItem.deployment = deployment;
       indexItem.type = 'Lab';
       indexItem.interactive = false;
-      indexItem._tags = ['labs'];
+      indexItem._tags = [tag];
     }
     algolia[cname][version].push(indexItem)
     algoliaCount++

--- a/extensions/find-related-labs.js
+++ b/extensions/find-related-labs.js
@@ -4,7 +4,7 @@ module.exports.register = function ({ config }) {
   const logger = this.getLogger('related-labs-extension');
 
   this.on('documentsConverted', async ({ contentCatalog, siteCatalog }) => {
-    const docs = contentCatalog.findBy({ component: 'ROOT', family: 'page' });
+    const docs = contentCatalog.findBy({ family: 'page' });
     docs.forEach((docPage) => {
       const relatedLabs = []
       const sourceAttributes = docPage.asciidoc.attributes
@@ -31,7 +31,7 @@ function findRelated(labPage, sourceCategoryList, sourceDeploymentType, logger) 
   const targetCategoryList = pageCategories.split(',').map(c => c.trim());
   const targetDeploymentType = getDeploymentType(targetAttributes)
   const categoryMatch = hasMatchingCategory(sourceCategoryList, targetCategoryList)
-  if (categoryMatch && (!targetDeploymentType ||sourceDeploymentType === targetDeploymentType || targetDeploymentType === 'Docker')) {
+  if (categoryMatch && (!targetDeploymentType ||sourceDeploymentType === targetDeploymentType || (targetDeploymentType === 'Docker' && !sourceDeploymentType))) {
     return {
       title: labPage.asciidoc.doctitle,
       url: labPage.pub.url,
@@ -45,7 +45,8 @@ function getDeploymentType (attributes) {
   return attributes['env-kubernetes'] ? 'Kubernetes'
     : attributes['env-linux'] ? 'Linux'
       : attributes['env-docker'] ? 'Docker'
-        : attributes.cloud ? 'Redpanda Cloud' : ''
+        : attributes['env-cloud'] ? 'Redpanda Cloud'
+          : attributes['page-cloud'] ? 'Redpanda Cloud' : ''
 }
 
 function hasMatchingCategory (sourcePageCategories, targetPageCategories) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.5.7",
+      "version": "3.5.8",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "~4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
Part of https://github.com/redpanda-data/documentation-private/issues/2587

Instead of having a different tag for Redpanda Labs, this PR updates the indexer to use the component title in all cases for consistency. We use these tags to filter results on the client side so having consistent tag names is important to avoid hardcoding custom tags.