### PR TITLE
Trigger npm update in all repos on publish

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -18,6 +18,7 @@ jobs:
         with:
           secret-ids: |
             ,sdlc/prod/github/npm_token
+            ,sdlc/prod/github/actions_bot_token
           parse-json-secrets: true
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -32,3 +33,9 @@ jobs:
       - name: Check published version
         if: ${{ steps.publish.outputs.type }}
         run: echo "Version changed!"
+      - uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ env.ACTIONS_BOT_TOKEN }}
+          repository: redpanda-data/docs
+          event-type: trigger-update
+          client-payload: '{"commit_sha": "${{ github.sha }}"}'

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -37,5 +37,5 @@ jobs:
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           repository: redpanda-data/docs
-          event-type: trigger-update
+          event-type: trigger-npm-update
           client-payload: '{"commit_sha": "${{ github.sha }}"}'

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -33,9 +33,16 @@ jobs:
       - name: Check published version
         if: ${{ steps.publish.outputs.type }}
         run: echo "Version changed!"
+  dispatch:
+    needs: publish
+    strategy:
+      matrix:
+        repo: ['redpanda-data/docs', 'redpanda-data/cloud-docs', 'redpanda-data/rp-connect-docs']
+    runs-on: ubuntu-latest
+    steps:
       - uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
-          repository: redpanda-data/docs
+          repository: ${{ matrix.repo }}
           event-type: trigger-npm-update
           client-payload: '{"commit_sha": "${{ github.sha }}"}'


### PR DESCRIPTION
Triggers the workflows introduced in https://github.com/redpanda-data/docs/pull/704 to update the package in other repos when a new npm release is launched.

Relies on https://github.com/redpanda-data/qa-infra/pull/107