### PR TITLE
Modify connect component visualization

### DIFF
--- a/extensions/generate-rp-connect-info.js
+++ b/extensions/generate-rp-connect-info.js
@@ -55,7 +55,7 @@ module.exports.register = function ({ config,contentCatalog }) {
           for (const file of connectPages) {
             const filePath = file.path;
             if (filePath.endsWith(`${connector}.adoc`) && filePath.includes(`pages/${type}s/`)) {
-              url = `../${type}s/${connector}`;
+              url = `${type}s/${connector}`;
               break;
             }
           }

--- a/extensions/generate-rp-connect-info.js
+++ b/extensions/generate-rp-connect-info.js
@@ -9,74 +9,74 @@ const GITHUB_REF = 'connect-csv'
 /* const csvUrl = 'https://localhost:3000/csv';
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; */
 
-module.exports.register = function ({ config,contentCatalog }) {
-    const logger = this.getLogger('redpanda-connect-info-extension');
+module.exports.register = function ({ config, contentCatalog }) {
+  const logger = this.getLogger('redpanda-connect-info-extension');
 
-    async function loadOctokit() {
-      const { Octokit } = await import('@octokit/rest');
-      if (!process.env.REDPANDA_GITHUB_TOKEN) return new Octokit()
-      return new Octokit({
-        auth: process.env.REDPANDA_GITHUB_TOKEN,
-      });
-    }
-
-    this.once('contentClassified', async ({ siteCatalog, contentCatalog }) => {
-        const redpandaConnect = contentCatalog.getComponents().find(component => component.name === 'redpanda-connect')
-        if (!redpandaConnect) return
-        const pages = contentCatalog.getPages()
-        try {
-            // Fetch CSV data and parse it
-            const csvData = await fetchCSV();
-            const parsedData = Papa.parse(csvData, { header: true, skipEmptyLines: true });
-            const enrichedData = enrichCsvDataWithUrls(parsedData,pages,logger);
-            parsedData.data = enrichedData
-            redpandaConnect.latest.asciidoc.attributes.csvData = parsedData;  
-            
-        } catch (error) {
-            logger.error('Error fetching or parsing CSV data:', error.message);
-            logger.error(error.stack);
-        }
+  async function loadOctokit() {
+    const { Octokit } = await import('@octokit/rest');
+    if (!process.env.REDPANDA_GITHUB_TOKEN) return new Octokit()
+    return new Octokit({
+      auth: process.env.REDPANDA_GITHUB_TOKEN,
     });
+  }
+
+  this.once('contentClassified', async ({ siteCatalog, contentCatalog }) => {
+    const redpandaConnect = contentCatalog.getComponents().find(component => component.name === 'redpanda-connect')
+    if (!redpandaConnect) return
+    const pages = contentCatalog.getPages()
+    try {
+      // Fetch CSV data and parse it
+      const csvData = await fetchCSV();
+      const parsedData = Papa.parse(csvData, { header: true, skipEmptyLines: true });
+      const enrichedData = enrichCsvDataWithUrls(parsedData, pages, logger);
+      parsedData.data = enrichedData
+      redpandaConnect.latest.asciidoc.attributes.csvData = parsedData;
+
+    } catch (error) {
+      logger.error('Error fetching or parsing CSV data:', error.message);
+      logger.error(error.stack);
+    }
+  });
 
   async function fetchCSV() {
-      const octokit = await loadOctokit();
-      try {
-        const { data: fileContent } = await octokit.rest.repos.getContent({
-          owner: GITHUB_OWNER,
-          repo: GITHUB_REPO,
-          path: CSV_PATH,
-          ref: GITHUB_REF,
-        });
-        return Buffer.from(fileContent.content, 'base64').toString('utf8');
-      } catch (error) {
-        console.error('Error fetching Redpanda Connect catalog from GitHub:', error);
-        return [];
-      }
+    const octokit = await loadOctokit();
+    try {
+      const { data: fileContent } = await octokit.rest.repos.getContent({
+        owner: GITHUB_OWNER,
+        repo: GITHUB_REPO,
+        path: CSV_PATH,
+        ref: GITHUB_REF,
+      });
+      return Buffer.from(fileContent.content, 'base64').toString('utf8');
+    } catch (error) {
+      console.error('Error fetching Redpanda Connect catalog from GitHub:', error);
+      return [];
     }
+  }
 
-    function enrichCsvDataWithUrls(parsedData, connectPages, logger) {
-        return parsedData.data.map(row => {
-          // Create a new object with trimmed keys and values
-        const trimmedRow = Object.fromEntries(
-          Object.entries(row).map(([key, value]) => [key.trim(), value.trim()])
-        );
-        const connector = trimmedRow.connector;
-        const type = trimmedRow.type;
-        let url = '';
-        for (const file of connectPages) {
-          const filePath = file.path;
-          if (filePath.endsWith(`${connector}.adoc`) && filePath.includes(`pages/${type}s/`)) {
-            url = `../${type}s/${connector}`;
-            break;
-          }
+  function enrichCsvDataWithUrls(parsedData, connectPages, logger) {
+    return parsedData.data.map(row => {
+      // Create a new object with trimmed keys and values
+      const trimmedRow = Object.fromEntries(
+        Object.entries(row).map(([key, value]) => [key.trim(), value.trim()])
+      );
+      const connector = trimmedRow.connector;
+      const type = trimmedRow.type;
+      let url = '';
+      for (const file of connectPages) {
+        const filePath = file.path;
+        if (filePath.endsWith(`${connector}.adoc`) && filePath.includes(`pages/${type}s/`)) {
+          url = `../${type}s/${connector}`;
+          break;
         }
-        if (!url) {
-          logger.warn(`No matching URL found for connector: ${connector} of type: ${type}`);
-        }
-        return {
-          ...trimmedRow,
-          url: url
-        };
-        });
       }
+      if (!url) {
+        logger.warn(`No matching URL found for connector: ${connector} of type: ${type}`);
+      }
+      return {
+        ...trimmedRow,
+        url: url
+      };
+    });
+  }
 }

--- a/extensions/generate-rp-connect-info.js
+++ b/extensions/generate-rp-connect-info.js
@@ -14,9 +14,9 @@ module.exports.register = function ({ config,contentCatalog }) {
 
     async function loadOctokit() {
       const { Octokit } = await import('@octokit/rest');
-      if (!process.env.GITHUB_TOKEN) return new Octokit()
+      if (!process.env.REDPANDA_GITHUB_TOKEN) return new Octokit()
       return new Octokit({
-        auth: process.env.GITHUB_TOKEN,
+        auth: process.env.REDPANDA_GITHUB_TOKEN,
       });
     }
 

--- a/extensions/generate-rp-connect-info.js
+++ b/extensions/generate-rp-connect-info.js
@@ -9,8 +9,8 @@ const GITHUB_REF = 'connect-csv'
 /* const csvUrl = 'https://localhost:3000/csv';
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; */
 
-module.exports.register = function ({ config, contentCatalog }) {
-  const logger = this.getLogger('redpanda-connect-info-extension');
+module.exports.register = function ({ config,contentCatalog }) {
+    const logger = this.getLogger('redpanda-connect-info-extension');
 
   async function loadOctokit() {
     const { Octokit } = await import('@octokit/rest');
@@ -22,6 +22,7 @@ module.exports.register = function ({ config, contentCatalog }) {
 
   this.once('contentClassified', async ({ siteCatalog, contentCatalog }) => {
     const redpandaConnect = contentCatalog.getComponents().find(component => component.name === 'redpanda-connect')
+    const redpandaCloud = contentCatalog.getComponents().find(component => component.name === 'redpanda-cloud')
     if (!redpandaConnect) return
     const pages = contentCatalog.getPages()
     try {
@@ -31,6 +32,7 @@ module.exports.register = function ({ config, contentCatalog }) {
       const enrichedData = enrichCsvDataWithUrls(parsedData, pages, logger);
       parsedData.data = enrichedData
       redpandaConnect.latest.asciidoc.attributes.csvData = parsedData;
+      redpandaCloud.latest.asciidoc.attributes.csvData = parsedData;
 
     } catch (error) {
       logger.error('Error fetching or parsing CSV data:', error.message);

--- a/extensions/generate-rp-connect-info.js
+++ b/extensions/generate-rp-connect-info.js
@@ -1,0 +1,70 @@
+'use strict'
+const https = require('https');
+const Papa = require('papaparse');
+
+//const csvUrl = 'https://raw.githubusercontent.com/redpanda-data/rp-connect-docs/connect-csv/redpanda_connect.csv';
+const csvUrl = 'https://localhost:3000/csv';
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+module.exports.register = function ({ config,contentCatalog }) {
+    const logger = this.getLogger('redpanda-connect-info-extension');
+
+    this.once('contentClassified', async ({ siteCatalog, contentCatalog }) => {
+        const redpandaConnect = contentCatalog.getComponents().find(component => component.name === 'redpanda-connect')
+        const pages = contentCatalog.getPages()
+        try {
+            // Fetch CSV data and parse it
+            const csvData = await fetchCSV(csvUrl);
+            const parsedData = Papa.parse(csvData, { header: true });
+            const enrichedData = enrichCsvDataWithUrls(parsedData,pages,logger);
+            parsedData.data = enrichedData
+            redpandaConnect.latest.asciidoc.attributes.csvData = parsedData;  
+            
+        } catch (error) {
+            logger.error('Error fetching or parsing CSV data:', error.message);
+            logger.error(error.stack);
+        }
+    });
+
+    function fetchCSV(url) {
+        return new Promise((resolve, reject) => {
+            https.get(url, (response) => {
+                let data = '';
+                response.on('data', (chunk) => {
+                    data += chunk;
+                });
+                response.on('end', () => {
+                    resolve(data);
+                });
+            }).on('error', (error) => {
+                reject(error);
+                logger.error('Error fetching or parsing CSV data:', error);
+            });
+        });
+    }
+
+    function enrichCsvDataWithUrls(parsedData, connectPages, logger) {
+        return parsedData.data.map(row => {
+          const connector = row.connector;
+          const type = row.type;
+          let url = '';
+      
+          for (const file of connectPages) {
+            const filePath = file.path;
+            if (filePath.endsWith(`${connector}.adoc`) && filePath.includes(`pages/${type}s/`)) {
+              url = `../${type}s/${connector}`;
+              break;
+            }
+          }
+      
+          if (!url) {
+            logger.warn(`No matching URL found for connector: ${connector} of type: ${type}`);
+          }
+      
+          return {
+            ...row,
+            url: url
+          };
+        });
+      }
+}

--- a/extensions/generate-rp-connect-info.js
+++ b/extensions/generate-rp-connect-info.js
@@ -12,6 +12,14 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; */
 module.exports.register = function ({ config,contentCatalog }) {
     const logger = this.getLogger('redpanda-connect-info-extension');
 
+    async function loadOctokit() {
+      const { Octokit } = await import('@octokit/rest');
+      if (!process.env.GITHUB_TOKEN) return new Octokit()
+      return new Octokit({
+        auth: process.env.GITHUB_TOKEN,
+      });
+    }
+
     this.once('contentClassified', async ({ siteCatalog, contentCatalog }) => {
         const redpandaConnect = contentCatalog.getComponents().find(component => component.name === 'redpanda-connect')
         if (!redpandaConnect) return

--- a/extensions/generate-rp-connect-info.js
+++ b/extensions/generate-rp-connect-info.js
@@ -39,6 +39,7 @@ module.exports.register = function ({ config,contentCatalog }) {
             }).on('error', (error) => {
                 reject(error);
                 logger.error('Error fetching or parsing CSV data:', error);
+                logger.error(error.stack);
             });
         });
     }

--- a/extensions/generate-rp-connect-info.js
+++ b/extensions/generate-rp-connect-info.js
@@ -56,26 +56,27 @@ module.exports.register = function ({ config,contentCatalog }) {
 
     function enrichCsvDataWithUrls(parsedData, connectPages, logger) {
         return parsedData.data.map(row => {
-          const connector = row.connector;
-          const type = row.type;
-          let url = '';
-      
-          for (const file of connectPages) {
-            const filePath = file.path;
-            if (filePath.endsWith(`${connector}.adoc`) && filePath.includes(`pages/${type}s/`)) {
-              url = `${type}s/${connector}`;
-              break;
-            }
+          // Create a new object with trimmed keys and values
+        const trimmedRow = Object.fromEntries(
+          Object.entries(row).map(([key, value]) => [key.trim(), value.trim()])
+        );
+        const connector = trimmedRow.connector;
+        const type = trimmedRow.type;
+        let url = '';
+        for (const file of connectPages) {
+          const filePath = file.path;
+          if (filePath.endsWith(`${connector}.adoc`) && filePath.includes(`pages/${type}s/`)) {
+            url = `../${type}s/${connector}`;
+            break;
           }
-      
-          if (!url) {
-            logger.warn(`No matching URL found for connector: ${connector} of type: ${type}`);
-          }
-      
-          return {
-            ...row,
-            url: url
-          };
+        }
+        if (!url) {
+          logger.warn(`No matching URL found for connector: ${connector} of type: ${type}`);
+        }
+        return {
+          ...trimmedRow,
+          url: url
+        };
         });
       }
 }

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -27,6 +27,7 @@ antora:
   - './extensions/version-fetcher/set-latest-version'
   - './extensions/algolia-indexer/index'
   - require: './extensions/generate-rp-connect-categories'
+  - require: './extensions/generate-rp-connect-info'
   - require: './extensions/unlisted-pages'
   - require: './extensions/replace-attributes-in-attachments'
   - require: './extensions/unpublish-pages'

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -9,6 +9,8 @@ content:
   - url: .
     branches: HEAD
     start_paths: [preview/extensions-and-macros, preview/shared]
+  - url: https://github.com/redpanda-data/rp-connect-docs
+    branches: main
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/macros/rp-connect-components.js
+++ b/macros/rp-connect-components.js
@@ -86,7 +86,7 @@ module.exports.register = function (registry, context) {
       const typesArray = Array.from(types.entries())
       .map(([type, { url, isCloudSupported }]) => {
           if (isCloudSupported) {
-              return url ? `<a href="../${url}">${type}</a>` : `<span>${type}</span>`;
+              return url ? `<a href="${url}/">${type}</a>` : `<span>${type}</span>`;
           } else {
               return '';
           }
@@ -100,7 +100,7 @@ module.exports.register = function (registry, context) {
         .join('');
 
       const connectorNameHtml = firstUrl
-        ? `<code><a href="../${firstUrl}">${connector}</a></code>`
+        ? `<code><a href="${firstUrl}/">${connector}</a></code>`
         : `<code><span>${connector}</span></code>`;
 
       if (isCloud) {
@@ -364,7 +364,7 @@ module.exports.register = function (registry, context) {
         <div class="page-type-dropdown">
           <p>Type: </p>
           <select class="type-dropdown" onchange="window.location.href=this.value">
-            ${sortedTypes.map(typeObj => `<option value="../${typeObj.url}" data-support="${typeObj.support}">${capitalize(typeObj.type)}</option>`).join('')}
+            ${sortedTypes.map(typeObj => `<option value="../${typeObj.url}/" data-support="${typeObj.support}">${capitalize(typeObj.type)}</option>`).join('')}
           </select>
         </div>
         <script>

--- a/macros/rp-connect-components.js
+++ b/macros/rp-connect-components.js
@@ -51,6 +51,38 @@ module.exports.register = function (registry, context) {
 
   let tabsCounter = 1; // Counter for generating unique IDs
 
+  const driverNameMap = {
+    "gocosmos": "Azure Cosmos DB",
+    "clickhouse": "ClickHouse",
+    "oracle": "Oracle",
+    "mssql": "Microsoft SQL Server",
+    "mysql": "MYSQL",
+    "snowflake": "Snowflake",
+    "postgresql": "PostgreSQL",
+    "postgres": "PostgreSQL",
+    "sqlite": "SQLite",
+    "trino": "Trino",
+  }
+
+  const cacheNameMap = {
+    "aws_dynamodb": "AWS DynamoDB",
+    "memcached": "Memcached",
+    "redis": "Redis",
+    "aws_s3": "AWS S3",
+    "memory": "Memory",
+    "ristretto": "Ristretto",
+    "couchbase": "Couchbase",
+    "mongodb": "MongoDB",
+    "sql": "SQL",
+    "file": "File",
+    "multilevel": "Multilevel",
+    "ttlru": "TTL LRU",
+    "gcp_cloud_storage": "GCP Cloud Storage",
+    "nats_kv": "NATS KV",
+    "lru": "LRU",
+    "noop": "Noop",
+  };
+
   // Add the category tabs for components
   registry.blockMacro(function () {
     const self = this;
@@ -112,8 +144,6 @@ module.exports.register = function (registry, context) {
     self.named('component_table');
     self.process((parent, target, attrs) => {
       const flatComponentsData = context.config?.attributes?.flatComponentsData || [];
-      const driverNameMap = context.config?.attributes?.drivers || [];
-      const cacheNameMap = context.config?.attributes?.caches || [];
       const driverSupportData = context.config?.attributes?.driverSupportData || {};
       const cacheSupportData = context.config?.attributes?.cacheSupportData || {};
 

--- a/macros/rp-connect-components.js
+++ b/macros/rp-connect-components.js
@@ -51,38 +51,6 @@ module.exports.register = function (registry, context) {
 
   let tabsCounter = 1; // Counter for generating unique IDs
 
-  const driverNameMap = {
-    "gocosmos": "Azure Cosmos DB",
-    "clickhouse": "ClickHouse",
-    "oracle": "Oracle",
-    "mssql": "Microsoft SQL Server",
-    "mysql": "MYSQL",
-    "snowflake": "Snowflake",
-    "postgresql": "PostgreSQL",
-    "postgres": "PostgreSQL",
-    "sqlite": "SQLite",
-    "trino": "Trino",
-  }
-
-  const cacheNameMap = {
-    "aws_dynamodb": "AWS DynamoDB",
-    "memcached": "Memcached",
-    "redis": "Redis",
-    "aws_s3": "AWS S3",
-    "memory": "Memory",
-    "ristretto": "Ristretto",
-    "couchbase": "Couchbase",
-    "mongodb": "MongoDB",
-    "sql": "SQL",
-    "file": "File",
-    "multilevel": "Multilevel",
-    "ttlru": "TTL LRU",
-    "gcp_cloud_storage": "GCP Cloud Storage",
-    "nats_kv": "NATS KV",
-    "lru": "LRU",
-    "noop": "Noop",
-  };
-
   // Add the category tabs for components
   registry.blockMacro(function () {
     const self = this;
@@ -144,6 +112,8 @@ module.exports.register = function (registry, context) {
     self.named('component_table');
     self.process((parent, target, attrs) => {
       const flatComponentsData = context.config?.attributes?.flatComponentsData || [];
+      const driverNameMap = context.config?.attributes?.drivers || [];
+      const cacheNameMap = context.config?.attributes?.caches || [];
       const driverSupportData = context.config?.attributes?.driverSupportData || {};
       const cacheSupportData = context.config?.attributes?.cacheSupportData || {};
 

--- a/macros/rp-connect-components.js
+++ b/macros/rp-connect-components.js
@@ -85,11 +85,16 @@ module.exports.register = function (registry, context) {
 
       const typesArray = Array.from(types.entries())
       .map(([type, { url, isCloudSupported }]) => {
-          if (isCloudSupported) {
-              return url ? `<a href="${url}/">${type}</a>` : `<span>${type}</span>`;
-          } else {
-              return '';
-          }
+          if(isCloud){
+            if (isCloudSupported) {
+                return url ? `<a href="${url}/">${type}</a>` : `<span>${type}</span>`;
+            } else {
+                return '';
+            }
+        }
+        else{
+          return url ? `<a href="${url}/">${type}</a>` : `<span>${type}</span>`;
+        }
       })
       .filter(item => item !== '');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.5.10",
+  "version": "3.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.5.10",
+      "version": "3.5.11",
       "license": "ISC",
       "dependencies": {
         "@octokit/core": "^6.1.2",
@@ -20,6 +20,7 @@
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "node-html-parser": "5.4.2-0",
+        "papaparse": "^5.4.1",
         "semver": "^7.6.0"
       },
       "devDependencies": {
@@ -5818,6 +5819,12 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true,
       "license": "(MIT AND Zlib)"
+    },
+    "node_modules/papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==",
+      "license": "MIT"
     },
     "node_modules/parse-filepath": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.5.11",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.5.11",
+      "version": "3.6.1",
       "license": "ISC",
       "dependencies": {
         "@octokit/core": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     },
     "./extensions/replace-attributes-in-attachments": "./extensions/replace-attributes-in-attachments.js",
     "./extensions/generate-rp-connect-categories": "./extensions/generate-rp-connect-categories.js",
+    "./extensions/generate-rp-connect-info": "./extensions/generate-rp-connect-info.js",
     "./extensions/add-global-attributes": "./extensions/add-global-attributes.js",
     "./extensions/version-fetcher/set-latest-version": "./extensions/version-fetcher/set-latest-version.js",
     "./extensions/modify-connect-tag-playbook": "./extensions/modify-connect-tag-playbook.js",
@@ -57,6 +58,9 @@
     "url": "git+https://github.com/redpanda-data/docs-extensions-and-macros"
   },
   "dependencies": {
+    "@octokit/core": "^6.1.2",
+    "@octokit/plugin-retry": "^7.1.1",
+    "@octokit/rest": "^21.0.1",
     "algoliasearch": "^4.17.0",
     "chalk": "4.1.2",
     "gulp": "^4.0.2",
@@ -65,10 +69,8 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "node-html-parser": "5.4.2-0",
-    "semver": "^7.6.0",
-    "@octokit/core": "^6.1.2",
-    "@octokit/plugin-retry": "^7.1.1",
-    "@octokit/rest": "^21.0.1"
+    "papaparse": "^5.4.1",
+    "semver": "^7.6.0"
   },
   "devDependencies": {
     "@antora/cli": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.6.1",
+  "version": "3.6.0",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.5.11",
+  "version": "3.6.1",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
Modify the visualization for connect components.  
Remove the datasource from the YAML and consider the CSV [redpanda_connect.csv](https://github.com/user-attachments/files/16874358/redpanda_connect.csv)

Remove the dropdown from the rows, and show a list of URLs instead.
Modify the filters to be multiple select. 
The filter works adding options. For example, 
- if a connector is of the type "input" and the filter have "input, output, processor" this connector will be shown.
- if a connector is of the type "output" and the filter have "input, output, processor" this connector will be shown.
- if a connector is of the type "processor" and the filter have "input, output " this connector will not be shown.


To run locally, run the rp-connect-docs repo, and modify the following to your local file 
https://github.com/redpanda-data/rp-connect-docs/blob/main/local-antora-playbook.yml#L28

For example: 'projects/antora/docs-extensions-and-macros/macros/rp-connect-components'