### PR TITLE
Set anchors to term titles

### DIFF
--- a/macros/glossary.js
+++ b/macros/glossary.js
@@ -82,7 +82,7 @@ module.exports.register = function (registry, config = {}) {
     }
   }
 
-  // Characters to replace by '-' in generated idprefix (no brackets in this regex)
+  // Characters to replace by '-' in generated idprefix
   const IDRX = /[\/ _.-]+/g
 
   function termId(term) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.6.5",
+  "version": "3.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.6.5",
+      "version": "3.6.6",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.6.5",
+  "version": "3.6.6",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
This PR addresses an issue where the `term-name` attribute was being used to generate anchor links for glossary terms. In some cases, the actual term title displayed on the page differed from the `term-name`, leading to broken or mismatched links.

To ensure consistency between the displayed term title and the anchor link, this update modifies the macro to always use the actual term title when building anchor links. This change guarantees that links point to the correct location based on the title shown on the page.