### PR TITLE
Add support for local files

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -226,7 +226,7 @@ antora:
 
 === Global attributes
 
-This extension collects Asciidoc attributes from the {url-playbook}[`shared` component] and makes them available to all component versions. Having global attributes is useful for consistent configuration of local and production builds.
+This extension collects Asciidoc attributes from the {url-playbook}[`shared` component] or a local YAML file and makes them available to all component versions. Having global attributes is useful for consistent configuration of local and production builds.
 
 ==== Environment variables
 
@@ -234,15 +234,20 @@ This extension does not require any environment variables.
 
 ==== Configuration options
 
-There are no configurable options for this extension.
+The extension accepts the following configuration options:
+
+attributespath (optional):: Specifies the path to a local YAML file that contains global attributes. If this is provided, the extension will load attributes from this file first. If this path is not provided or no valid attributes are found in the file, the extension will fall back to loading attributes from the `shared` component.
 
 ==== Registration example
 
-```yaml
+```yml
 antora:
   extensions:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/add-global-attributes'
+    attributespath: './local-attributes.yml'
 ```
+
+In this example, the `attributespath` option points to a local YAML file (`./local-attributes.yml`), which contains the global attributes. The extension will load attributes from this file first before falling back to the `shared` component.
 
 === Produce redirects (customization of core Antora)
 
@@ -305,15 +310,32 @@ This extension does not require any environment variables.
 
 ==== Configuration options
 
-There are no configurable options for this extension.
+The extension accepts the following configuration options:
+
+termspath (optional):: Specifies the path to a local directory containing term files (in `.adoc` format). If this path is provided, the extension will attempt to load terms from this directory first. If this path is not provided or no valid terms are found in the specified directory, the extension will fall back to loading terms from the `shared` component.
+
+Term files should follow the following structure:
+
+```asciidoc
+:category: Documentation
+:hover-text: This is a description of the term.
+:link: https://example.com
+
+== Term Title
+
+This is the detailed description of the term.
+```
 
 ==== Registration example
 
-```yaml
+```yml
 antora:
   extensions:
-  - '@redpanda-data/docs-extensions-and-macros/extensions/aggregate-terms'
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/aggregate-terms'
+    termspath: './local-terms/'
 ```
+
+In this example, the `termspath` option points to a local directory (./local-terms/), where the term files are stored. The extension will load terms from this directory first before falling back to the `shared` component.
 
 === Unlisted pages
 

--- a/extensions/add-global-attributes.js
+++ b/extensions/add-global-attributes.js
@@ -4,33 +4,83 @@
  *    - require: ./extensions/add-global-attributes.js
 */
 
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const _ = require('lodash');
+
+const ATTRIBUTES_PATH = 'modules/ROOT/partials/';  // Default path within the 'shared' component
+
 module.exports.register = function ({ config }) {
-  const yaml = require('js-yaml');
   const logger = this.getLogger('global-attributes-extension');
-  const chalk = require('chalk')
-  const _ = require('lodash');
+  const chalk = require('chalk');
+
+  /**
+   * Load global attributes from a specified local file if provided.
+   */
+  function loadLocalAttributes(siteCatalog, localAttributesFile) {
+    try {
+      const resolvedPath = path.resolve(localAttributesFile);
+      if (!fs.existsSync(resolvedPath)) {
+        logger.warn(`Local attributes file "${localAttributesFile}" does not exist.`);
+        return false;  // Return false if the local file doesn't exist
+      }
+
+      const fileContents = fs.readFileSync(resolvedPath, 'utf8');
+      const fileAttributes = yaml.load(fileContents);
+
+      siteCatalog.attributeFile = _.merge({}, fileAttributes);
+      console.log(chalk.green(`Loaded global attributes from local file "${localAttributesFile}".`));
+      return true;  // Return true if the local attributes were successfully loaded
+
+    } catch (error) {
+      logger.error(`Error loading local attributes from "${localAttributesFile}": ${error.message}`);
+      return false;  // Return false if an error occurs
+    }
+  }
 
   this.on('contentAggregated', ({ siteCatalog, contentAggregate }) => {
     try {
-      for (const component of contentAggregate) {
-        if (component.name === 'shared') {
-          const attributeFiles = component.files.filter(file => file.path.startsWith('modules/ROOT/partials/') && file.path.endsWith('.yml'));
-          if (!attributeFiles.length) {
-            logger.warn("No YAML attributes files found in 'shared' component.");
-          } else {
-            siteCatalog.attributeFile = attributeFiles.reduce((acc, file) => {
-              const fileAttributes = yaml.load(file.contents.toString('utf8'));
-              return _.merge(acc, fileAttributes);
-            }, {});
-            console.log(chalk.green('Loaded global attributes from shared component.'));
+      let attributesLoaded = false;
+
+      // Try to load attributes from the local file if provided
+      if (config.attributespath) {
+        attributesLoaded = loadLocalAttributes(siteCatalog, config.attributespath);
+      }
+
+      // If no local attributes were loaded, fallback to the 'shared' component
+      if (!attributesLoaded) {
+        let sharedComponentFound = false;
+
+        for (const component of contentAggregate) {
+          if (component.name === 'shared') {
+            sharedComponentFound = true;
+            const attributeFiles = component.files.filter(file => file.path.startsWith(ATTRIBUTES_PATH) && file.path.endsWith('.yml'));
+
+            if (!attributeFiles.length) {
+              logger.warn(`No YAML attributes files found in 'shared' component in ${ATTRIBUTES_PATH}.`);
+            } else {
+              siteCatalog.attributeFile = attributeFiles.reduce((acc, file) => {
+                const fileAttributes = yaml.load(file.contents.toString('utf8'));
+                return _.merge(acc, fileAttributes);
+              }, {});
+              console.log(chalk.green('Loaded global attributes from shared component.'));
+            }
+            break;
           }
-          break;
+        }
+
+        // If no 'shared' component is found, log a warning
+        if (!sharedComponentFound) {
+          logger.warn("No component named 'shared' found in the content and no valid local attributes file provided. Global attributes will not be available. You may see Asciidoc warnings about missing attributes and some behavior may not work as expected.");
         }
       }
+
     } catch (error) {
       logger.error(`Error loading attributes: ${error.message}`);
     }
   })
+
   .on('contentClassified', async ({ siteCatalog, contentCatalog }) => {
     const components = await contentCatalog.getComponents();
     for (let i = 0; i < components.length; i++) {
@@ -39,7 +89,7 @@ module.exports.register = function ({ config }) {
         if (siteCatalog.attributeFile) {
           asciidoc.attributes = _.merge({}, siteCatalog.attributeFile, asciidoc.attributes);
         }
-      })
+      });
     }
-  })
-}
+  });
+};

--- a/extensions/add-global-attributes.js
+++ b/extensions/add-global-attributes.js
@@ -55,7 +55,7 @@ module.exports.register = function ({ config }) {
         for (const component of contentAggregate) {
           if (component.name === 'shared') {
             sharedComponentFound = true;
-            const attributeFiles = component.files.filter(file => file.path.startsWith(ATTRIBUTES_PATH) && file.path.endsWith('.yml'));
+            const attributeFiles = component.files.filter(file => (file.path.startsWith(ATTRIBUTES_PATH) && file.path.endsWith('.yml')));
 
             if (!attributeFiles.length) {
               logger.warn(`No YAML attributes files found in 'shared' component in ${ATTRIBUTES_PATH}.`);

--- a/extensions/validate-attributes.js
+++ b/extensions/validate-attributes.js
@@ -11,7 +11,9 @@ module.exports.register = function ({ config }) {
 
   this.on('documentsConverted', async ({ contentCatalog, siteCatalog }) => {
     // Retrieve valid categories and subcategories from site attributes defined in add-global-attributes.js.
+    if (!siteCatalog.attributeFile) return logger.warn('No global attributes file available - skipping attribute validation. Check global-attributes-extension for errors')
     const validCategories = siteCatalog.attributeFile['page-valid-categories'];
+    if (!validCategories) return logger.warn('No page-valid-categories attribute found - skipping attribute validation')
     const categoryMap = createCategoryMap(validCategories);
     const pages = contentCatalog.findBy({ family: 'page' });
     pages.forEach((page) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.6.6",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.6.6",
+      "version": "3.7.0",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.6.6",
+  "version": "3.7.0",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
This PR adds support for providing local terms files as well as a local attributes file. This feature is useful for local development where you want to test the extension or you don't want to rely on loading the `shared` component from GitHub or the local filesystem.

For details, see https://github.com/redpanda-data/docs-extensions-and-macros/pull/77/files#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124

This PR also adds better log messages and fixes a bug where you couldn't build the docs without the `shared` component available in the playbook.