### PR TITLE
DOC-611 Hide Enterprise license metadata in Cloud contexts

### DIFF
--- a/macros/rp-connect-components.js
+++ b/macros/rp-connect-components.js
@@ -619,7 +619,7 @@ module.exports.register = function (registry, context) {
   });
 
   /**
-   * Registers a block macro to generate a dropdown for component types and display metadata about the selected component.
+   * Registers a block macro to display metadata about the selected component.
    *
    * This macro creates a dropdown to select different types of a connector component, such as Input, Output, or Processor.
    * It also provides links to the corresponding Cloud or Self-Managed documentation for the selected component type, and  displays information on whether the connector requires an enterprise license.
@@ -697,11 +697,13 @@ module.exports.register = function (registry, context) {
         sortedTypes.unshift(currentType);
       }
       // Check if the component requires an Enterprise license (based on support level)
-      const requiresEnterprise = componentRows.some(row => row.is_licensed.toLowerCase() === 'yes');
       let enterpriseLicenseInfo = '';
-      if (requiresEnterprise) {
-        enterpriseLicenseInfo = `
-          <p><strong>License</strong>: This component requires an <a href="https://redpanda.com/compare-platform-editions" target="_blank">Enterprise license</a>. To upgrade, contact <a href="https://redpanda.com/try-redpanda?section=enterprise-trial" target="_blank" rel="noopener">Redpanda sales</a>.</p>`;
+      if (component !== 'Cloud') {
+        const requiresEnterprise = componentRows.some(row => row.is_licensed.toLowerCase() === 'yes');
+        if (requiresEnterprise) {
+          enterpriseLicenseInfo = `
+            <p><strong>License</strong>: This component requires an <a href="https://redpanda.com/compare-platform-editions" target="_blank">Enterprise license</a>. To upgrade, contact <a href="https://redpanda.com/try-redpanda?section=enterprise-trial" target="_blank" rel="noopener">Redpanda sales</a>.</p>`;
+        }
       }
       const isCloudSupported = componentRows.some(row => row.is_cloud_supported === 'y');
       let availableInInfo = '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
Previews:
- [Cloud](https://deploy-preview-79--docs-extensions-and-macros.netlify.app/redpanda-cloud/develop/connect/components/inputs/redpanda_migrator/)
- [Self-Managed](https://deploy-preview-79--docs-extensions-and-macros.netlify.app/redpanda-connect/components/inputs/redpanda_migrator/)