### PR TITLE
Support beta in tests

### DIFF
--- a/extensions/version-fetcher/get-latest-connect.js
+++ b/extensions/version-fetcher/get-latest-connect.js
@@ -2,8 +2,7 @@ module.exports = async (github, owner, repo) => {
 
   try {
     const release = await github.rest.repos.getLatestRelease({ owner, repo });
-    tag = release.data.tag_name.replace(/^v/, '');
-    return tag;
+    return release.data.tag_name
   } catch (error) {
     console.error(error);
     return null;

--- a/extensions/version-fetcher/get-latest-console-version.js
+++ b/extensions/version-fetcher/get-latest-console-version.js
@@ -1,5 +1,5 @@
 module.exports = async (github, owner, repo) => {
-  const semver = require('semver')
+  const semver = require('semver');
   try {
     const releases = await github.rest.repos.listReleases({
       owner,
@@ -8,15 +8,14 @@ module.exports = async (github, owner, repo) => {
       per_page: 50
     });
 
-    // Filter valid semver tags and sort them
+    // Filter tags with valid semver format
     const sortedReleases = releases.data
-      .map(release => release.tag_name.replace(/^v/, ''))
-      .filter(tag => semver.valid(tag))
-      // Sort in descending order to get the highest version first
-      .sort(semver.rcompare);
+      .map(release => release.tag_name)
+      .filter(tag => semver.valid(tag.replace(/^v/, '')))
+      .sort((a, b) => semver.rcompare(a.replace(/^v/, ''), b.replace(/^v/, '')));
 
     if (sortedReleases.length > 0) {
-      // Return the highest version
+      // Return the highest version with "v" prefix
       return sortedReleases[0];
     } else {
       console.log("No valid semver releases found.");

--- a/extensions/version-fetcher/get-latest-redpanda-version.js
+++ b/extensions/version-fetcher/get-latest-redpanda-version.js
@@ -11,14 +11,14 @@ module.exports = async (github, owner, repo) => {
 
     // Filter valid semver tags, exclude drafts, and sort them to find the highest version
     const sortedReleases = releases.data
-      .filter(release => !release.draft)
-      .map(release => release.tag_name)
-      .filter(tag => semver.valid(tag.replace(/^v/, '')))
-      .sort((a, b) => semver.rcompare(a.replace(/^v/, ''), b.replace(/^v/, '')));
-
+    .filter(release => !release.draft)
+    .map(release => release.tag_name)
+    .filter(tag => semver.valid(tag.replace(/^v/, '')))
+    .sort((a, b) => semver.rcompare(a.replace(/^v/, ''), b.replace(/^v/, '')));
+  
     if (sortedReleases.length > 0) {
-      const latestRedpandaReleaseVersion = sortedReleases.find(tag => !tag.includes('rc'));
-      const latestRcReleaseVersion = sortedReleases.find(tag => tag.includes('rc'));
+      const latestRedpandaReleaseVersion = sortedReleases.find(tag => !tag.includes('-rc'));
+      const latestRcReleaseVersion = sortedReleases.find(tag => tag.includes('-rc'));
 
       // Get the commit hash for the highest version tag
       const commitData = await github.rest.git.getRef({

--- a/extensions/version-fetcher/get-latest-redpanda-version.js
+++ b/extensions/version-fetcher/get-latest-redpanda-version.js
@@ -12,10 +12,9 @@ module.exports = async (github, owner, repo) => {
     // Filter valid semver tags, exclude drafts, and sort them to find the highest version
     const sortedReleases = releases.data
       .filter(release => !release.draft)
-      .map(release => release.tag_name.replace(/^v/, ''))
-      .filter(tag => semver.valid(tag))
-      // Sort in descending order to get the highest version first
-      .sort(semver.rcompare);
+      .map(release => release.tag_name)
+      .filter(tag => semver.valid(tag.replace(/^v/, '')))
+      .sort((a, b) => semver.rcompare(a.replace(/^v/, ''), b.replace(/^v/, '')));
 
     if (sortedReleases.length > 0) {
       const latestRedpandaReleaseVersion = sortedReleases.find(tag => !tag.includes('rc'));
@@ -25,7 +24,7 @@ module.exports = async (github, owner, repo) => {
       const commitData = await github.rest.git.getRef({
         owner,
         repo,
-        ref: `tags/v${latestRedpandaReleaseVersion}`
+        ref: `tags/${latestRedpandaReleaseVersion}`
       });
       const latestRedpandaReleaseCommitHash = commitData.data.object.sha;
 
@@ -34,7 +33,7 @@ module.exports = async (github, owner, repo) => {
         const rcCommitData = await github.rest.git.getRef({
           owner,
           repo,
-          ref: `tags/v${latestRcReleaseVersion}`
+          ref: `tags/${latestRcReleaseVersion}`
         });
         latestRcReleaseCommitHash = rcCommitData.data.object.sha;
       }

--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -77,11 +77,8 @@ module.exports.register = function ({ config }) {
 
           // Special handling for Redpanda RC versions if in beta
           if (latestVersions.redpanda?.latestRcRelease?.version) {
-            const betaVersion = sanitizeVersion(latestVersions.redpanda.latestRcRelease.version);
-            asciidoc.attributes['redpanda-beta-version'] = betaVersion;
-            asciidoc.attributes['redpanda-beta-tag'] = `v${betaVersion}`;
+            setVersionAndTagAttributes(asciidoc, 'redpanda-beta', latestVersions.redpanda.latestRcRelease.version, name, version)
             asciidoc.attributes['redpanda-beta-commit'] = latestVersions.redpanda.latestRcRelease.commitHash;
-            logger.info(`Set Redpanda RC version ${betaVersion} (tag: v${betaVersion}) in ${name} ${version}`);
           }
         });
 
@@ -91,7 +88,7 @@ module.exports.register = function ({ config }) {
         if (semver.valid(latestVersions.redpanda?.latestRedpandaRelease?.version)) {
           const currentVersion = component.latest.asciidoc.attributes['full-version'] || '0.0.0';
           if (semver.gt(latestVersions.redpanda.latestRedpandaRelease.version, currentVersion)) {
-            component.latest.asciidoc.attributes['full-version'] = latestVersions.redpanda.latestRedpandaRelease.version;
+            component.latest.asciidoc.attributes['full-version'] = sanitizeVersion(latestVersions.redpanda.latestRedpandaRelease.version);
             setVersionAndTagAttributes(component.latest.asciidoc, 'latest-redpanda', latestVersions.redpanda.latestRedpandaRelease.version);
             component.latest.asciidoc.attributes['latest-release-commit'] = latestVersions.redpanda.latestRedpandaRelease.commitHash;
             logger.info(`Updated Redpanda release version to ${latestVersions.redpanda.latestRedpandaRelease.version}`);
@@ -110,12 +107,12 @@ module.exports.register = function ({ config }) {
     if (versionData) {
       const versionWithoutPrefix = sanitizeVersion(versionData);
       asciidoc.attributes[`${baseName}-version`] = versionWithoutPrefix; // Without "v" prefix
-      asciidoc.attributes[`${baseName}-tag`] = `v${versionWithoutPrefix}`; // With "v" prefix
+      asciidoc.attributes[`${baseName}-tag`] = `${versionData}`;
 
       if (name && version) {
-        logger.info(`Set ${baseName}-version to ${versionWithoutPrefix} and ${baseName}-tag to v${versionWithoutPrefix} in ${name} ${version}`);
+        logger.info(`Set ${baseName}-version to ${versionWithoutPrefix} and ${baseName}-tag to ${versionData} in ${name} ${version}`);
       } else {
-        logger.info(`Updated ${baseName}-version to ${versionWithoutPrefix} and ${baseName}-tag to v${versionWithoutPrefix}`);
+        logger.info(`Updated ${baseName}-version to ${versionWithoutPrefix} and ${baseName}-tag to ${versionData}`);
       }
     }
   }

--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -1,13 +1,14 @@
 module.exports.register = function ({ config }) {
-  const GetLatestRedpandaVersion = require('./get-latest-redpanda-version')
-  const GetLatestConsoleVersion = require('./get-latest-console-version')
-  const GetLatestOperatorVersion = require('./get-latest-operator-version')
-  const GetLatestHelmChartVersion = require('./get-latest-redpanda-helm-version')
-  const GetLatestConnectVersion = require('./get-latest-connect')
-  const chalk = require('chalk')
-  const logger = this.getLogger('set-latest-version-extension')
+  const GetLatestRedpandaVersion = require('./get-latest-redpanda-version');
+  const GetLatestConsoleVersion = require('./get-latest-console-version');
+  const GetLatestOperatorVersion = require('./get-latest-operator-version');
+  const GetLatestHelmChartVersion = require('./get-latest-redpanda-helm-version');
+  const GetLatestConnectVersion = require('./get-latest-connect');
+  const chalk = require('chalk');
+  const logger = this.getLogger('set-latest-version-extension');
+
   if (!process.env.REDPANDA_GITHUB_TOKEN) {
-    logger.warn('REDPANDA_GITHUB_TOKEN environment variable not set. Attempting unauthenticated request.')
+    logger.warn('REDPANDA_GITHUB_TOKEN environment variable not set. Attempting unauthenticated request.');
   }
 
   this.on('contentClassified', async ({ contentCatalog }) => {
@@ -17,83 +18,85 @@ module.exports.register = function ({ config }) {
     const OctokitWithRetries = Octokit.plugin(retry);
 
     const owner = 'redpanda-data';
-
-    let githubOptions = {
+    const githubOptions = {
       userAgent: 'Redpanda Docs',
       baseUrl: 'https://api.github.com',
+      auth: process.env.REDPANDA_GITHUB_TOKEN || undefined,
     };
-
-    if (process.env.REDPANDA_GITHUB_TOKEN) {
-      githubOptions.auth = process.env.REDPANDA_GITHUB_TOKEN;
-    }
-
     const github = new OctokitWithRetries(githubOptions);
+
     try {
-      const results = await Promise.allSettled([
+      const [
+        latestRedpandaResult,
+        latestConsoleResult,
+        latestOperatorResult,
+        latestHelmChartResult,
+        latestConnectResult,
+      ] = await Promise.allSettled([
         GetLatestRedpandaVersion(github, owner, 'redpanda'),
         GetLatestConsoleVersion(github, owner, 'console'),
         GetLatestOperatorVersion(github, owner, 'redpanda-operator'),
         GetLatestHelmChartVersion(github, owner, 'helm-charts', 'charts/redpanda/Chart.yaml'),
-        GetLatestConnectVersion(github, owner, 'connect')
-      ])
+        GetLatestConnectVersion(github, owner, 'connect'),
+      ]);
 
-      const LatestRedpandaVersion = results[0].status === 'fulfilled' ? results[0].value : null
-      const LatestConsoleVersion = results[1].status === 'fulfilled' ? results[1].value : null
-      const LatestOperatorVersion = results[2].status === 'fulfilled' ? results[2].value : null
-      const LatestHelmChartVersion = results[3].status === 'fulfilled' ? results[3].value : null
-      const LatestConnectVersion = results[4].status === 'fulfilled' ? results[4].value : null
+      const latestVersions = {
+        redpanda: latestRedpandaResult.status === 'fulfilled' ? latestRedpandaResult.value : null,
+        console: latestConsoleResult.status === 'fulfilled' ? latestConsoleResult.value : null,
+        operator: latestOperatorResult.status === 'fulfilled' ? latestOperatorResult.value : null,
+        helmChart: latestHelmChartResult.status === 'fulfilled' ? latestHelmChartResult.value : null,
+        connect: latestConnectResult.status === 'fulfilled' ? latestConnectResult.value : null,
+      };
 
-      const components = await contentCatalog.getComponents()
+      const components = await contentCatalog.getComponents();
       components.forEach(component => {
-        let prerelease = component.latestPrerelease;
+        const prerelease = component.latestPrerelease;
+
         component.versions.forEach(({ name, version, asciidoc }) => {
-          // This attribute is used for conditionally rendering content for beta releases.
-          // It is also used in the `unpublish-pages` extension to unpublish beta pages that aren't part of a beta version.
-          if (prerelease && prerelease.version === version) {
-            asciidoc.attributes['page-component-version-is-prerelease'] = 'true'
+          if (prerelease?.version === version) {
+            asciidoc.attributes['page-component-version-is-prerelease'] = 'true';
           }
-          if (LatestConsoleVersion) {
-            asciidoc.attributes['latest-console-version'] = `${LatestConsoleVersion}@`
-            logger.info(`Set Redpanda Console version to ${LatestConsoleVersion} in ${name} ${version}`)
-          }
-          if (LatestConnectVersion) {
-            asciidoc.attributes['latest-connect-version'] = `${LatestConnectVersion}@`
-            logger.info(`Set Redpanda Connect version to ${LatestConnectVersion} in ${name} ${version}`)
-          }
-          if (LatestRedpandaVersion && LatestRedpandaVersion.latestRcRelease && LatestRedpandaVersion.latestRcRelease.version) {
-            asciidoc.attributes['redpanda-beta-version'] = `${LatestRedpandaVersion.latestRcRelease.version}@`
-            asciidoc.attributes['redpanda-beta-commit'] = `${LatestRedpandaVersion.latestRcRelease.commitHash}@`
-            logger.info(`Updated to latest Redpanda RC version: ${LatestRedpandaVersion.latestRcRelease.version} with commit: ${LatestRedpandaVersion.latestRcRelease.commitHash}`)
-        }
-        })
 
-        if (!component.latest.asciidoc) {
-          component.latest.asciidoc = { attributes: {} }
-        }
+          setVersionAttribute(asciidoc, 'latest-console-version', latestVersions.console, name, version);
+          setVersionAttribute(asciidoc, 'latest-connect-version', latestVersions.connect, name, version);
 
-        if (LatestRedpandaVersion && LatestRedpandaVersion.latestRedpandaRelease && semver.valid(LatestRedpandaVersion.latestRedpandaRelease.version)) {
-          let currentVersion = component.latest.asciidoc.attributes['full-version'] || '0.0.0'
-          if (semver.gt(LatestRedpandaVersion.latestRedpandaRelease.version, currentVersion)) {
-            component.latest.asciidoc.attributes['full-version'] = `${LatestRedpandaVersion.latestRedpandaRelease.version}@`
-            component.latest.asciidoc.attributes['latest-release-commit'] = `${LatestRedpandaVersion.latestRedpandaRelease.commitHash}@`
-            logger.info(`Updated to latest Redpanda version: ${LatestRedpandaVersion.latestRedpandaRelease.version} with commit: ${LatestRedpandaVersion.latestRedpandaRelease.commitHash}`)
+          if (latestVersions.redpanda?.latestRcRelease?.version) {
+            asciidoc.attributes['redpanda-beta-version'] = `v${latestVersions.redpanda.latestRcRelease.version}`;
+            asciidoc.attributes['redpanda-beta-commit'] = `${latestVersions.redpanda.latestRcRelease.commitHash}`;
+            logger.info(`Set Redpanda RC version ${latestVersions.redpanda.latestRcRelease.version} in ${name} ${version}`);
+          }
+        });
+
+        if (!component.latest.asciidoc) component.latest.asciidoc = { attributes: {} };
+
+        if (semver.valid(latestVersions.redpanda?.latestRedpandaRelease?.version)) {
+          const currentVersion = component.latest.asciidoc.attributes['full-version'] || '0.0.0';
+          if (semver.gt(latestVersions.redpanda.latestRedpandaRelease.version, currentVersion)) {
+            component.latest.asciidoc.attributes['full-version'] = `${latestVersions.redpanda.latestRedpandaRelease.version}`;
+            component.latest.asciidoc.attributes['latest-redpanda-version'] = `v${latestVersions.redpanda.latestRedpandaRelease.version}`;
+            component.latest.asciidoc.attributes['latest-release-commit'] = `${latestVersions.redpanda.latestRedpandaRelease.commitHash}`;
+            logger.info(`Updated Redpanda release version to ${latestVersions.redpanda.latestRedpandaRelease.version}`);
           }
         }
 
-        if (LatestOperatorVersion) {
-          component.latest.asciidoc.attributes['latest-operator-version'] = `${LatestOperatorVersion}@`
-          logger.info(`Updated to latest Redpanda Operator version: ${LatestOperatorVersion}`)
-        }
+        setVersionAttribute(component.latest.asciidoc, 'latest-operator-version', latestVersions.operator);
+        setVersionAttribute(component.latest.asciidoc, 'latest-redpanda-helm-chart-version', latestVersions.helmChart);
+      });
 
-        if (LatestHelmChartVersion) {
-          component.latest.asciidoc.attributes['latest-redpanda-helm-chart-version'] = `${LatestHelmChartVersion}@`
-          logger.info(`Updated to latest Redpanda Helm chart version: ${LatestHelmChartVersion}`)
-        }
-      })
-
-      console.log(`${chalk.green('Updated Redpanda documentation versions successfully.')}`)
+      console.log(chalk.green('Updated Redpanda documentation versions successfully.'));
     } catch (error) {
-      logger.error(`Error updating versions: ${error}`)
+      logger.error(`Error updating versions: ${error}`);
     }
-  })
-}
+  });
+
+  function setVersionAttribute(asciidoc, attributeName, versionData, name, version) {
+    if (versionData) {
+      asciidoc.attributes[attributeName] = `${versionData}`;
+      if (name && version) {
+        logger.info(`Set ${attributeName} to ${versionData} in ${name} ${version}`);
+      } else {
+        logger.info(`Updated ${attributeName} to ${versionData}`);
+      }
+    }
+  }
+};

--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -74,7 +74,6 @@ module.exports.register = function ({ config }) {
           if (latestVersions.connect) {
             setVersionAndTagAttributes(asciidoc, 'latest-connect', latestVersions.connect, name, version);
           }
-
           // Special handling for Redpanda RC versions if in beta
           if (latestVersions.redpanda?.latestRcRelease?.version) {
             setVersionAndTagAttributes(asciidoc, 'redpanda-beta', latestVersions.redpanda.latestRcRelease.version, name, version)
@@ -88,8 +87,9 @@ module.exports.register = function ({ config }) {
         if (semver.valid(latestVersions.redpanda?.latestRedpandaRelease?.version)) {
           const currentVersion = component.latest.asciidoc.attributes['full-version'] || '0.0.0';
           if (semver.gt(latestVersions.redpanda.latestRedpandaRelease.version, currentVersion)) {
+            // Required for backwards compatibility. Some docs still use full-version
             component.latest.asciidoc.attributes['full-version'] = sanitizeVersion(latestVersions.redpanda.latestRedpandaRelease.version);
-            setVersionAndTagAttributes(component.latest.asciidoc, 'latest-redpanda', latestVersions.redpanda.latestRedpandaRelease.version);
+            setVersionAndTagAttributes(component.latest.asciidoc, 'latest-redpanda', latestVersions.redpanda.latestRedpandaRelease.version, component.latest.name, component.latest.version);
             component.latest.asciidoc.attributes['latest-release-commit'] = latestVersions.redpanda.latestRedpandaRelease.commitHash;
             logger.info(`Updated Redpanda release version to ${latestVersions.redpanda.latestRedpandaRelease.version}`);
           }

--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -59,7 +59,7 @@ module.exports.register = function ({ config }) {
             asciidoc.attributes['page-component-version-is-prerelease'] = 'true';
           }
 
-          // Conditionally set operator and helm chart attributes only if data is available
+          // Set operator and helm chart attributes
           if (latestVersions.operator) {
             asciidoc.attributes['latest-operator-version'] = latestVersions.operator;
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.7.2",
+      "version": "3.7.3",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/preview/extensions-and-macros/antora.yml
+++ b/preview/extensions-and-macros/antora.yml
@@ -9,4 +9,5 @@ asciidoc:
     replace-attributes-in-attachments: true
     test-attribute: This attribute was replaced by the `replace-attributes-in-attachments` extension.
     full-version: 23.2.1
+    latest-redpanda-version: v23.2.1
     latest-release-commit: 'This should get replaced'

--- a/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
@@ -74,6 +74,7 @@ helm_ref:storage[]
 The `version fetcher` extension gets the latest version of Redpanda and Redpanda Console and assigns them to the following attributes:
 
 - `\{full-version}`: {full-version}
+- `\{latest-redpanda-version}`: {latest-redpanda-version}
 - `\{latest-release-commit}`: {latest-release-commit}
 - `\{latest-console-version}`: {latest-console-version}
 - `\{latest-operator-version}`: {latest-operator-version}


### PR DESCRIPTION
To support testing Docker Compose files for both beta (unstable) and GA (general availability) versions, this PR modifies the  extension to dynamically replace specific environment variables based on the release type. These environment variables are used in our automated tests, but we don't want to force users to set them, so this change replaces them dynamically.

- If `page-component-version-is-prerelease` is set, `${REDPANDA_DOCKER_REPO:-redpanda}` is replaced with `redpanda-unstable`, indicating the beta Docker repo.
- If `page-component-version-is-prerelease` is not set, the placeholder defaults to `redpanda` for the GA Docker repo.

Here's an example snippet from the quickstart:
```yaml
    image: docker.redpanda.com/redpandadata/${REDPANDA_DOCKER_REPO:-redpanda}:${REDPANDA_VERSION:-latest}
    container_name: redpanda-0
```
In this case, our Doc Detective tests will set the environment variables or use the fallbacks so we can test during GA and beta. But we want to single-source the same file into docs without requiring users to set them. So, the extension is responsible for finding `REDPANDA_DOCKER_REPO` and dynamically changing it to `redpanda-unstable` when the doc is a beta or `redpanda` otherwise.

We also now capture raw tags to avoid having to add the `v` prefix for certain use cases, which is error-prone. So each `latest-<product>` attribute has both a `version` and a `tag` option. `version` is the raw version number and `tag` is the release tag, including any `v` prefixes.