### PR TITLE
Fetch draft RC releases

### DIFF
--- a/extensions/generate-rp-connect-categories.js
+++ b/extensions/generate-rp-connect-categories.js
@@ -6,7 +6,7 @@ module.exports.register = function ({ config }) {
   this.once('contentClassified', ({ siteCatalog, contentCatalog }) => {
     const redpandaConnect = contentCatalog.getComponents().find(component => component.name === 'redpanda-connect')
     if (!redpandaConnect || !redpandaConnect.latest) {
-      logger.info('Could not find the redpanda-connect component')
+      logger.warn('Could not find the redpanda-connect component. Skipping category creation.')
       return
     }
 
@@ -116,7 +116,8 @@ module.exports.register = function ({ config }) {
       redpandaConnect.latest.asciidoc.attributes.driverSupportData = driverSupportData
       redpandaConnect.latest.asciidoc.attributes.cacheSupportData = cacheSupportData
 
-      logger.info(`Added Redpanda Connect data to latest Asciidoc object: ${JSON.stringify({ connectCategoriesData, flatComponentsData }, null, 2)}`)
+      logger.info(`Added Redpanda Connect data to latest Asciidoc object.`)
+      logger.debug(`${JSON.stringify({ connectCategoriesData, flatComponentsData }, null, 2)}`)
     } catch (error) {
       logger.error(`Error processing Redpanda Connect files: ${error.message}`)
     }

--- a/extensions/version-fetcher/get-latest-redpanda-version.js
+++ b/extensions/version-fetcher/get-latest-redpanda-version.js
@@ -9,13 +9,12 @@ module.exports = async (github, owner, repo) => {
       per_page: 50
     });
 
-    // Filter valid semver tags, exclude drafts, and sort them to find the highest version
+    // Filter valid semver tags and sort them to find the highest version
     const sortedReleases = releases.data
-    .filter(release => !release.draft)
     .map(release => release.tag_name)
     .filter(tag => semver.valid(tag.replace(/^v/, '')))
     .sort((a, b) => semver.rcompare(a.replace(/^v/, ''), b.replace(/^v/, '')));
-  
+
     if (sortedReleases.length > 0) {
       const latestRedpandaReleaseVersion = sortedReleases.find(tag => !tag.includes('-rc'));
       const latestRcReleaseVersion = sortedReleases.find(tag => tag.includes('-rc'));

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -10,7 +10,7 @@ content:
     branches: HEAD
     start_paths: [preview/extensions-and-macros, preview/shared]
   - url: https://github.com/redpanda-data/docs
-    branches: [main, v/*, api, 'site-search', '!v-end-of-life/*']
+    branches: [main, v/*, api, v-WIP/24.3, 'site-search', '!v-end-of-life/*']
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.7.3",
+      "version": "3.7.4",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
@@ -75,6 +75,7 @@ The `version fetcher` extension gets the latest version of Redpanda and Redpanda
 
 - `\{full-version}`: {full-version}
 - `\{latest-redpanda-version}`: {latest-redpanda-version}
+- `\{redpanda-beta-version}`: {redpanda-beta-version}
 - `\{latest-release-commit}`: {latest-release-commit}
 - `\{latest-console-version}`: {latest-console-version}
 - `\{latest-operator-version}`: {latest-operator-version}


### PR DESCRIPTION
As confirmed in Slack, RC releases remain in draft during the beta period. This PR adjusts our version fetcher to also fetch draft RC releases. https://redpandadata.slack.com/archives/C029XT7FLQ2/p1730760990578389?thread_ts=1730745624.768939&cid=C029XT7FLQ2

It also stops outputting large JSON objects in INFO logs so that they are less noisy.