### PR TITLE
DOC-736 Fetch console beta releases

### DIFF
--- a/extensions/find-related-docs.js
+++ b/extensions/find-related-docs.js
@@ -54,7 +54,7 @@ module.exports.register = function ({ config }) {
       }
 
       if (uniqueRelatedDocs.length > 0 || uniqueRelatedLabs.length > 0) {
-        logger.info(`Set related docs and labs attributes for ${labPage.asciidoc.doctitle}`);
+        logger.debug(`Set related docs and labs attributes for ${labPage.asciidoc.doctitle}`);
       }
     });
   });

--- a/extensions/find-related-labs.js
+++ b/extensions/find-related-labs.js
@@ -19,7 +19,7 @@ module.exports.register = function ({ config }) {
       })
       if (!relatedLabs.length) return
       docPage.asciidoc.attributes['page-related-labs'] = JSON.stringify(relatedLabs)
-      logger.info(`Set page-related-labs attribute for ${docPage.asciidoc.doctitle} to ${docPage.asciidoc.attributes['page-related-labs']}`)
+      logger.debug(`Set page-related-labs attribute for ${docPage.asciidoc.doctitle} to ${docPage.asciidoc.attributes['page-related-labs']}`)
     })
   })
 }

--- a/extensions/replace-attributes-in-attachments.js
+++ b/extensions/replace-attributes-in-attachments.js
@@ -37,9 +37,12 @@ module.exports.register = function () {
       ? sanitizeAttributeValue(attributes['latest-redpanda-tag'] || '')
       : sanitizeAttributeValue(attributes['full-version'] || ''));
 
-      const consoleVersion = useTagAttributes
-        ? sanitizeAttributeValue(attributes['latest-console-tag'] || '')
-        : sanitizeAttributeValue(attributes['latest-console-version'] || '');
+      const consoleVersion = isPrerelease
+      ? sanitizeAttributeValue(attributes['console-beta-tag'] || '')
+      : (useTagAttributes
+      ? sanitizeAttributeValue(attributes['latest-console-tag'] || '')
+      : sanitizeAttributeValue(attributes['latest-console-version'] || ''));
+
       const redpandaRepo = isPrerelease ? 'redpanda-unstable' : 'redpanda';
       const consoleRepo = 'console';
 

--- a/extensions/version-fetcher/get-latest-console-version.js
+++ b/extensions/version-fetcher/get-latest-console-version.js
@@ -1,6 +1,7 @@
 module.exports = async (github, owner, repo) => {
   const semver = require('semver');
   try {
+    // Fetch all the releases from the repository
     const releases = await github.rest.repos.listReleases({
       owner,
       repo,
@@ -8,21 +9,27 @@ module.exports = async (github, owner, repo) => {
       per_page: 50
     });
 
-    // Filter tags with valid semver format
+    // Filter valid semver tags and sort them to find the highest version
     const sortedReleases = releases.data
       .map(release => release.tag_name)
       .filter(tag => semver.valid(tag.replace(/^v/, '')))
       .sort((a, b) => semver.rcompare(a.replace(/^v/, ''), b.replace(/^v/, '')));
 
     if (sortedReleases.length > 0) {
-      // Return the highest version with "v" prefix
-      return sortedReleases[0];
+      // Find the highest versions for stable and beta releases
+      const latestStableReleaseVersion = sortedReleases.find(tag => !tag.includes('-beta'));
+      const latestBetaReleaseVersion = sortedReleases.find(tag => tag.includes('-beta'));
+
+      return {
+        latestStableRelease: latestStableReleaseVersion || null,
+        latestBetaRelease: latestBetaReleaseVersion || null
+      };
     } else {
       console.log("No valid semver releases found.");
-      return null;
+      return { latestStableRelease: null, latestBetaRelease: null };
     }
   } catch (error) {
-    console.error(error);
-    return null;
+    console.error('Failed to fetch release information:', error);
+    return { latestStableRelease: null, latestBetaRelease: null };
   }
 };

--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -69,7 +69,7 @@ module.exports.register = function ({ config }) {
 
           // Set attributes for console and connect versions
           if (latestVersions.console) {
-            setVersionAndTagAttributes(asciidoc, 'latest-console', latestVersions.console, name, version);
+            setVersionAndTagAttributes(asciidoc, 'latest-console', latestVersions.console.latestStableRelease, name, version);
           }
           if (latestVersions.connect) {
             setVersionAndTagAttributes(asciidoc, 'latest-connect', latestVersions.connect, name, version);
@@ -77,6 +77,7 @@ module.exports.register = function ({ config }) {
           // Special handling for Redpanda RC versions if in beta
           if (latestVersions.redpanda?.latestRcRelease?.version) {
             setVersionAndTagAttributes(asciidoc, 'redpanda-beta', latestVersions.redpanda.latestRcRelease.version, name, version)
+            setVersionAndTagAttributes(asciidoc, 'console-beta', latestVersions.console.latestBetaRelease, name, version);
             asciidoc.attributes['redpanda-beta-commit'] = latestVersions.redpanda.latestRcRelease.commitHash;
           }
         });
@@ -91,12 +92,18 @@ module.exports.register = function ({ config }) {
             component.latest.asciidoc.attributes['full-version'] = sanitizeVersion(latestVersions.redpanda.latestRedpandaRelease.version);
             setVersionAndTagAttributes(component.latest.asciidoc, 'latest-redpanda', latestVersions.redpanda.latestRedpandaRelease.version, component.latest.name, component.latest.version);
             component.latest.asciidoc.attributes['latest-release-commit'] = latestVersions.redpanda.latestRedpandaRelease.commitHash;
-            logger.info(`Updated Redpanda release version to ${latestVersions.redpanda.latestRedpandaRelease.version}`);
           }
         }
       });
 
       console.log(chalk.green('Updated Redpanda documentation versions successfully.'));
+      logger.info(`Latest Redpanda version: ${latestVersions.redpanda.latestRedpandaRelease.version}`);
+      if (latestVersions.redpanda.latestRCRelease) logger.info(`Latest Redpanda beta version: ${latestVersions.redpanda.latestRCRelease.version}`);
+      logger.info(`Latest Connect version: ${latestVersions.connect}`);
+      logger.info(`Latest Console version: ${latestVersions.console.latestStableRelease}`);
+      if (latestVersions.console.latestBetaRelease) logger.info(`Latest Console beta version: ${latestVersions.console.latestBetaRelease}`);
+      logger.info(`Latest Redpanda Helm chart version: ${latestVersions.helmChart}`);
+      logger.info(`Latest Operator version: ${latestVersions.operator}`);
     } catch (error) {
       logger.error(`Error updating versions: ${error}`);
     }
@@ -110,9 +117,9 @@ module.exports.register = function ({ config }) {
       asciidoc.attributes[`${baseName}-tag`] = `${versionData}`;
 
       if (name && version) {
-        logger.info(`Set ${baseName}-version to ${versionWithoutPrefix} and ${baseName}-tag to ${versionData} in ${name} ${version}`);
+        logger.debug(`Set ${baseName}-version to ${versionWithoutPrefix} and ${baseName}-tag to ${versionData} in ${name} ${version}`);
       } else {
-        logger.info(`Updated ${baseName}-version to ${versionWithoutPrefix} and ${baseName}-tag to ${versionData}`);
+        logger.debug(`Updated ${baseName}-version to ${versionWithoutPrefix} and ${baseName}-tag to ${versionData}`);
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.7.4",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.7.4",
+      "version": "3.8.0",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.7.4",
+  "version": "3.8.0",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
@@ -76,8 +76,11 @@ The `version fetcher` extension gets the latest version of Redpanda and Redpanda
 - `\{full-version}`: {full-version}
 - `\{latest-redpanda-version}`: {latest-redpanda-version}
 - `\{redpanda-beta-version}`: {redpanda-beta-version}
+- `\{redpanda-beta-tag}`: {redpanda-beta-tag}
 - `\{latest-release-commit}`: {latest-release-commit}
 - `\{latest-console-version}`: {latest-console-version}
+- `\{console-beta-version}`: {console-beta-version}
+- `\{console-beta-tag}`: {console-beta-tag}
 - `\{latest-operator-version}`: {latest-operator-version}
 - `\{latest-redpanda-helm-chart-version}`: {latest-redpanda-helm-chart-version}
 


### PR DESCRIPTION
We need this to unblock https://github.com/redpanda-data/docs/pull/825 so that the quickstart uses the correct version of Console.

[Preview of fetched versions and related Asciidoc attributes](https://deploy-preview-82--docs-extensions-and-macros.netlify.app/preview/test/#latest-versions)