### PR TITLE
DOC-725 Update rpcn macro to show all supported connectors

### DIFF
--- a/macros/rp-connect-components.js
+++ b/macros/rp-connect-components.js
@@ -389,13 +389,15 @@ module.exports.register = function (registry, context) {
             supportLevelStr += `<p>${certifiedDrivers}${certifiedDrivers && communityDrivers ? '</br> ' : ''}${communityDrivers}</p>`;
           }
         }
-        // Build the cloud support column
+        // Build the cloud support column and include the connector URL where a connector page is available. Otherwise, just mark as available.
         const firstCloudSupportedType = Array.from(types.entries())
           .map(([_, commercialNames]) => Object.values(commercialNames).find(({ isCloudSupported }) => isCloudSupported))
-          .find(entry => entry && entry.urls.redpandaCloudUrl);
+          .find(entry => entry);
         const cloudLinkDisplay = firstCloudSupportedType
-          ? `<a href="${firstCloudSupportedType.urls.redpandaCloudUrl}">Yes</a>`
-          : 'No';
+          ? firstCloudSupportedType.urls.redpandaCloudUrl
+            ? `<a href="${firstCloudSupportedType.urls.redpandaCloudUrl}">Yes</a>`
+          : `Yes`
+        : 'No';
 
         const firstUrl = getFirstUrlFromTypesArray(Array.from(types.entries()), isCloud);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
Resolves: https://redpandadata.atlassian.net/browse/DOC-725

Updated rpcn macro to allow catalog to show all supported connectors. 

Cloud supported column shows `Yes` with a link to the connector page when available, or just `Yes` if the connector page is not yet in the docs.

https://deploy-preview-83--docs-extensions-and-macros.netlify.app/preview/test/#connector-table-with-all-data

Tested successfully: I have a ticket to add `http_client` input and output and `http_processor` to Cloud docs as support for them has recently been added. They are correctly showing as cloud supported but without a link.