### PR TITLE
Add archive attachments extension

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -220,14 +220,14 @@ antora:
 
 *Outcome*: Separate archives for each component version.
 
-For each matching (component, version) pair, the extension creates a distinct archive named `<component-title>-<version>-<output_archive>`. For example:
-`self-managed-24.3-redpanda-quickstart.tar.gz`.
+For each matching (component, version) pair, the extension creates a distinct archive named `<version>-<output_archive>`. For example:
+`24.3-redpanda-quickstart.tar.gz`.
 
 These archives are placed at the site root, ensuring they are easily accessible and do not overwrite each other.
 
 For the latest version of each component, the extension also adds the archive using the base `output_archive` name. As a result, the latest archives are accessible through a consistent filename, facilitating easy downloads without needing to reference version numbers.
 
-Because each archive has a unique filename based on the component and version, there is no risk of archives overwriting each other.
+Because each archive has a unique filename based on the component version, there is no risk of archives overwriting each other.
 The only exception is the archive for the latest version, which consistently uses the `output_archive` name.
 
 === Component category aggregator

--- a/README.adoc
+++ b/README.adoc
@@ -165,6 +165,63 @@ antora:
     index-latest-only: true
 ```
 
+=== Archive attachments
+
+The `archive-attachments` extension automates the packaging of specific attachment files into a compressed archive (`.tar.gz`) based on configurable patterns. This archive is then made available to the generated site, allowing users to easily download grouped resources such as Docker Compose configurations.
+
+This extension enables you to define which files and directories to include in the archive, ensuring that only relevant content is packaged and accessible.
+
+==== Environment variables
+
+This extension does not require any environment variables.
+
+==== Configuration options
+
+The extension accepts the following options in the Antora playbook.
+
+- `output_archive` (required): The name of the archive file to be created and placed at the site root. Example: `'redpanda-quickstart.tar.gz'`.
+
+- `file_patterns` (required): An array of glob patterns that specify which attachment paths to include in the archive. These patterns determine the files and directories to be packaged based on their paths within the content catalog.
+
+NOTE: Ensure that `file_patterns` accurately reflect the paths of the attachments you wish to archive. Overly broad patterns may include unintended files, while overly restrictive patterns might exclude necessary resources.
+
+==== Example configuration
+
+Here's an example configuration to enable the archive-creation extension:
+
+```yaml
+antora:
+  extensions:
+    - require: '../docs-extensions-and-macros/extensions/archive-creation-extension.js'
+      output_archive: 'redpanda-quickstart.tar.gz' <1>
+      file_patterns:
+        - '**/test-resources/**/docker-compose/**' <2>
+```
+
+<1> Defines the name of the generated archive placed at the site root.
+<2> Lists the glob patterns to match attachment paths for inclusion in the archive.
++
+- `**`: Matches any number of directories.
+- `/test-resources/`: Specifies that the matching should occur within the `test-resources/` directory.
+- `/docker-compose/`: Targets the `docker-compose/` directory and all its subdirectories.
+- `**:` Ensures that all files and nested directories within `docker-compose/` are included.
+
+=== Behavior with multiple components/versions
+
+*Scenario*: Multiple components and/or multiple versions of the same component contain attachments that match the defined file_patterns.
+
+*Outcome*: Separate archives for each component version.
+
+For each matching (component, version) pair, the extension creates a distinct archive named `<component-title>-<version>-<output_archive>`. For example:
+`self-managed-24.3-redpanda-quickstart.tar.gz`.
+
+These archives are placed at the site root, ensuring they are easily accessible and do not overwrite each other.
+
+For the latest version of each component, the extension also adds the archive using the base `output_archive` name. As a result, the latest archives are accessible through a consistent filename, facilitating easy downloads without needing to reference version numbers.
+
+Because each archive has a unique filename based on the component and version, there is no risk of archives overwriting each other.
+The only exception is the archive for the latest version, which consistently uses the `output_archive` name.
+
 === Component category aggregator
 
 This extension maps Redpanda Connect component data into a structured format:
@@ -465,9 +522,8 @@ antora:
 
 This extension replaces AsciiDoc attribute placeholders with their respective values in attachment files, such as CSS, HTML, and YAML.
 
-[IMPORTANT]
+[NOTE]
 ====
-- This extension processes attachments only if the component version includes the attribute `replace-attributes-in-attachments: true`.
 - The `@` character is removed from attribute values to prevent potential issues with CSS or HTML syntax.
 - If the same attribute placeholder is used multiple times within a file, all instances will be replaced with the attribute's value.
 ====
@@ -478,7 +534,13 @@ This extension does not require any environment variables.
 
 ==== Configuration options
 
-There are no configurable options for this extension.
+The extension accepts the following options in the Antora playbook.
+
+- `data.files` (required): An array of glob patterns specifying which attachment files to process. These patterns determine the files that will undergo attribute replacement based on their paths within the content catalog.
+
+- `custom_replacements` (optional): Lists the custom search-and-replace rules to be applied to the matched files.
+
+NOTE: Ensure that `data.files` accurately reflect the paths of the attachments you wish to use. Overly broad patterns may include unintended files, while overly restrictive patterns might exclude necessary resources.
 
 ==== Registration example
 
@@ -486,6 +548,13 @@ There are no configurable options for this extension.
 antora:
   extensions:
   - '@redpanda-data/docs-extensions-and-macros/extensions/replace-attributes-in-attachments'
+  data:
+    files:
+      - '**/*.yml'
+      - '**/*.yaml'
+    custom_replacements:
+      - search: 'shadow indexing'
+        replace: 'Tiered Storage'
 ```
 
 === Aggregate terms

--- a/README.adoc
+++ b/README.adoc
@@ -179,27 +179,35 @@ This extension does not require any environment variables.
 
 The extension accepts the following options in the Antora playbook.
 
-- `output_archive` (required): The name of the archive file to be created and placed at the site root. Example: `'redpanda-quickstart.tar.gz'`.
+Configure the extension in your Antora playbook by defining an array of archive configurations under `data.archives`. Each archive configuration includes:
 
-- `file_patterns` (required): An array of glob patterns that specify which attachment paths to include in the archive. These patterns determine the files and directories to be packaged based on their paths within the content catalog.
+output_archive (string, required):: The name of the generated archive file.
 
-NOTE: Ensure that `file_patterns` accurately reflect the paths of the attachments you wish to archive. Overly broad patterns may include unintended files, while overly restrictive patterns might exclude necessary resources.
+component (string, required):: The name of the Antora component whose attachments should be archived.
+
+file_patterns (array of strings, required):: Glob patterns specifying which attachment paths to include in the archive.
+
+NOTE: Ensure that `file_patterns` accurately reflect the paths of the attachments you want to archive. Overly broad patterns may include unintended files, while overly restrictive patterns might exclude necessary resources.
 
 ==== Example configuration
 
-Here's an example configuration to enable the archive-creation extension:
+Here's an example configuration to enable the extension:
 
 ```yaml
 antora:
   extensions:
     - require: '../docs-extensions-and-macros/extensions/archive-creation-extension.js'
-      output_archive: 'redpanda-quickstart.tar.gz' <1>
-      file_patterns:
-        - '**/test-resources/**/docker-compose/**' <2>
+      data:
+        archives:
+          - output_archive: 'redpanda-quickstart.tar.gz' <1>
+            component: 'ROOT' <2>
+            file_patterns:
+              - '**/test-resources/**/docker-compose/**' <3>
 ```
 
 <1> Defines the name of the generated archive placed at the site root.
-<2> Lists the glob patterns to match attachment paths for inclusion in the archive.
+<2> Defines the name of the component in which to search for attachments.
+<3> Lists the glob patterns to match attachment paths for inclusion in the archive.
 +
 - `**`: Matches any number of directories.
 - `/test-resources/`: Specifies that the matching should occur within the `test-resources/` directory.
@@ -520,7 +528,7 @@ antora:
 
 === Replace attributes in attachments
 
-This extension replaces AsciiDoc attribute placeholders with their respective values in attachment files, such as CSS, HTML, and YAML.
+This extension automates the replacement of AsciiDoc attribute placeholders with their respective values within attachment files, such as CSS, HTML, and YAML.
 
 [NOTE]
 ====
@@ -534,27 +542,46 @@ This extension does not require any environment variables.
 
 ==== Configuration options
 
-The extension accepts the following options in the Antora playbook.
+The extension accepts the following configuration options in the Antora playbook:
 
-- `data.files` (required): An array of glob patterns specifying which attachment files to process. These patterns determine the files that will undergo attribute replacement based on their paths within the content catalog.
+data.replacements (required):: An array of replacement configurations. Each configuration can target multiple components and define specific file patterns and custom replacement rules.
 
-- `custom_replacements` (optional): Lists the custom search-and-replace rules to be applied to the matched files.
+* `components` (array of strings, required): Lists the names of the Antora components whose attachments should undergo attribute replacement.
 
-NOTE: Ensure that `data.files` accurately reflect the paths of the attachments you wish to use. Overly broad patterns may include unintended files, while overly restrictive patterns might exclude necessary resources.
+* `file_patterns` (array of strings, required): Glob patterns specifying which attachment files to process. These patterns determine the files that will undergo attribute replacement based on their paths within the content catalog.
 
-==== Registration example
+* `custom_replacements` (array of objects, optional): Defines custom search-and-replace rules to be applied to the matched files. Each rule consists of:
+** `search` (string, required): A regular expression pattern to search for within the file content.
+** `replace` (string, required): The string to replace each match found by the `search` pattern.
+
+NOTE: Ensure that `file_patterns` accurately reflect the paths of the attachments you want to process. Overly broad patterns may include unintended files, while overly restrictive patterns might exclude necessary resources.
+
+==== Registration Example
+
+This is an example of how to register and configure the `replace-attributes-in-attachments` extension in your Antora playbook. This example demonstrates defining multiple replacement configurations, each targeting different components and specifying their own file patterns and custom replacements.
 
 ```yaml
 antora:
   extensions:
-  - '@redpanda-data/docs-extensions-and-macros/extensions/replace-attributes-in-attachments'
-  data:
-    files:
-      - '**/*.yml'
-      - '**/*.yaml'
-    custom_replacements:
-      - search: 'shadow indexing'
-        replace: 'Tiered Storage'
+    - require: './extensions/replace-attributes-in-attachments'
+      data:
+        replacements:
+          - components:
+              - 'ROOT'
+              - 'redpanda-labs'
+            file_patterns:
+              - '**/docker-compose.yaml'
+              - '**/docker-compose.yml'
+            custom_replacements:
+              - search: ''\\$\\{CONFIG_FILE:[^}]*\\}''
+                replace: 'console.yaml'
+          - components:
+              - 'API'
+            file_patterns:
+              - '**/api-docs/**/resources/**'
+            custom_replacements:
+              - search: '\\$\\{API_ENDPOINT:[^}]*\\}'
+                replace: 'https://api.example.com'
 ```
 
 === Aggregate terms

--- a/extensions/archive-attachments.js
+++ b/extensions/archive-attachments.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const tar = require('tar');
+const micromatch = require('micromatch');
+const { PassThrough } = require('stream');
+
+/**
+ * Utility function to create a tar.gz archive in memory.
+ * @param {string} tempDir - The temporary directory containing files to archive.
+ * @returns {Promise<Buffer>} - A promise that resolves to the tar.gz buffer.
+ */
+function createTarInMemory(tempDir) {
+  return new Promise((resolve, reject) => {
+    const pass = new PassThrough();
+    const chunks = [];
+
+    pass.on('data', (chunk) => chunks.push(chunk));
+    pass.on('error', (error) => reject(error));
+    pass.on('end', () => resolve(Buffer.concat(chunks)));
+
+    tar
+      .create(
+        {
+          gzip: true,
+          cwd: tempDir,
+        },
+        ['.']
+      )
+      .pipe(pass)
+      .on('error', (err) => reject(err));
+  });
+}
+
+module.exports.register = function ({ config }) {
+  const logger = this.getLogger('archive-attachments-extension');
+  const outputArchive = config.data?.output_archive;
+  const filePatterns = config.data?.file_patterns || [];
+
+  // Validate configuration
+  if (!outputArchive) {
+    logger.info('No `output_archive` provided. Archive creation skipped.');
+    return;
+  }
+  if (!filePatterns.length) {
+    logger.info('No `file_patterns` provided. Archive creation skipped.');
+    return;
+  }
+
+  this.on('beforePublish', async ({ contentCatalog, siteCatalog }) => {
+    logger.info('Starting archive creation process');
+
+    const components = contentCatalog.getComponents();
+
+    for (const comp of components) {
+      for (const compVer of comp.versions) {
+        const compName = comp.name;
+        const compVersion = compVer.version;
+        const latest = comp.latest?.version || 0;
+
+        const isLatest = latest === compVersion ? true : false
+
+        logger.debug(`Processing component: ${compName}, version: ${compVersion}`);
+
+        // Gather attachments for this component version
+        const attachments = contentCatalog.findBy({
+          component: compName,
+          version: compVersion,
+          family: 'attachment',
+        });
+
+        logger.debug(`Found ${attachments.length} attachments for ${compName}@${compVersion}`);
+
+        if (!attachments.length) {
+          logger.debug(`No attachments found for ${compName}@${compVersion}, skipping.`);
+          continue;
+        }
+
+        // Filter attachments based on filePatterns
+        const matched = attachments.filter((attachment) =>
+          micromatch.isMatch(attachment.out.path, filePatterns)
+        );
+
+        logger.debug(`Matched ${matched.length} attachments for ${compName}@${compVersion}`);
+
+        if (!matched.length) {
+          logger.debug(`No attachments matched patterns for ${compName}@${compVersion}, skipping.`);
+          continue;
+        }
+
+        // Create a temporary directory and write matched attachments
+        const tempDir = path.join('/tmp', `${compName}-${compVersion}-${Date.now()}`);
+        try {
+          fs.mkdirSync(tempDir, { recursive: true });
+          logger.debug(`Created temporary directory: ${tempDir}`);
+
+          for (const attachment of matched) {
+            const relPath = attachment.out.path;
+            // Include only the part of the path after '_attachments/'
+            const attachmentsSegment = '_attachments/';
+            const attachmentsIndex = relPath.indexOf(attachmentsSegment);
+
+            if (attachmentsIndex === -1) {
+              logger.warn(`'_attachments/' segment not found in path: ${relPath}. Skipping this file.`);
+              continue;
+            }
+
+            // Extract the path starting after '_attachments/'
+            const relativePath = relPath.substring(attachmentsIndex + attachmentsSegment.length);
+
+            const destPath = path.join(tempDir, relativePath);
+            fs.mkdirSync(path.dirname(destPath), { recursive: true });
+            fs.writeFileSync(destPath, attachment.contents);
+            logger.debug(`Written file to tempDir: ${destPath}`);
+          }
+
+          // Asynchronously create the tar.gz archive in memory
+          logger.debug(`Starting tar creation for ${compName}@${compVersion}`);
+          const archiveBuffer = await createTarInMemory(tempDir);
+          logger.debug(`Tar creation completed for ${compName}@${compVersion}`);
+
+          // Define the output path for the archive in the site
+          const archiveOutPath = `${compVer.title}${compVersion?'-' + compVersion:''}-${outputArchive}`.toLowerCase()
+
+          // Add the archive to siteCatalog
+          siteCatalog.addFile({
+            contents: archiveBuffer,
+            out: { path: archiveOutPath },
+          });
+
+          if (isLatest) {
+            siteCatalog.addFile({
+              contents: archiveBuffer,
+              out: { path: path.basename(outputArchive) },
+            });
+          }
+
+          logger.info(`Archive added to site at: ${archiveOutPath}`);
+
+        } catch (error) {
+          logger.error(`Error processing ${compName}@${compVersion}:`, error);
+        } finally {
+          // Clean up the temporary directory
+          try {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+            logger.debug(`Cleaned up temporary directory: ${tempDir}`);
+          } catch (cleanupError) {
+            logger.error(`Error cleaning up tempDir ${tempDir}:`, cleanupError);
+          }
+        }
+      }
+    }
+    logger.info('Archive creation process completed');
+  });
+};

--- a/extensions/archive-attachments.js
+++ b/extensions/archive-attachments.js
@@ -1,24 +1,25 @@
-'use strict';
+"use strict";
 
-const fs = require('fs');
-const path = require('path');
-const tar = require('tar');
-const micromatch = require('micromatch');
-const { PassThrough } = require('stream');
+const fs = require("fs");
+const path = require("path");
+const tar = require("tar");
+const micromatch = require("micromatch");
+const { PassThrough } = require("stream");
+const os = require("os"); // For accessing the system's temp directory
 
 /**
  * Create a tar.gz archive in memory.
  * @param {string} tempDir - The temporary directory containing files to archive.
  * @returns {Promise<Buffer>} - A promise that resolves to the tar.gz buffer.
  */
-function createTarInMemory(tempDir) {
+async function createTarInMemory(tempDir) {
   return new Promise((resolve, reject) => {
     const pass = new PassThrough();
     const chunks = [];
 
-    pass.on('data', (chunk) => chunks.push(chunk));
-    pass.on('error', (error) => reject(error));
-    pass.on('end', () => resolve(Buffer.concat(chunks)));
+    pass.on("data", (chunk) => chunks.push(chunk));
+    pass.on("error", (error) => reject(error));
+    pass.on("end", () => resolve(Buffer.concat(chunks)));
 
     tar
       .create(
@@ -26,25 +27,25 @@ function createTarInMemory(tempDir) {
           gzip: true,
           cwd: tempDir,
         },
-        ['.']
+        ["."]
       )
       .pipe(pass)
-      .on('error', (err) => reject(err));
+      .on("error", (err) => reject(err));
   });
 }
 
 module.exports.register = function ({ config }) {
-  const logger = this.getLogger('archive-attachments-extension');
+  const logger = this.getLogger("archive-attachments-extension");
   const archives = config.data?.archives || [];
 
   // Validate configuration
   if (!archives.length) {
-    logger.info('No `archives` configurations provided. Archive creation skipped.');
+    logger.info("No `archives` configurations provided. Archive creation skipped.");
     return;
   }
 
-  this.on('beforePublish', async ({ contentCatalog, siteCatalog }) => {
-    logger.info('Starting archive creation process');
+  this.on("beforePublish", async ({ contentCatalog, siteCatalog }) => {
+    logger.info("Starting archive creation process");
 
     const components = contentCatalog.getComponents();
 
@@ -53,7 +54,7 @@ module.exports.register = function ({ config }) {
 
       // Validate individual archive configuration
       if (!output_archive) {
-        logger.warn('An `archive` configuration is missing `output_archive`. Skipping this archive.');
+        logger.warn("An `archive` configuration is missing `output_archive`. Skipping this archive.");
         continue;
       }
       if (!component) {
@@ -77,7 +78,7 @@ module.exports.register = function ({ config }) {
       for (const compVer of comp.versions) {
         const compName = comp.name;
         const compVersion = compVer.version;
-        const latest = comp.latest?.version || '';
+        const latest = comp.latest?.version || "not latest";
 
         const isLatest = latest === compVersion;
 
@@ -87,7 +88,7 @@ module.exports.register = function ({ config }) {
         const attachments = contentCatalog.findBy({
           component: compName,
           version: compVersion,
-          family: 'attachment',
+          family: "attachment",
         });
 
         logger.debug(`Found ${attachments.length} attachments for ${compName}@${compVersion}`);
@@ -98,6 +99,7 @@ module.exports.register = function ({ config }) {
         }
 
         // Filter attachments based on file_patterns
+        const attachmentsSegment = "_attachments/";
         const matched = attachments.filter((attachment) =>
           micromatch.isMatch(attachment.out.path, file_patterns)
         );
@@ -110,19 +112,17 @@ module.exports.register = function ({ config }) {
         }
 
         // Create a temporary directory and write matched attachments
-        const tempDir = path.join('/tmp', `${compName}-${compVersion}-${Date.now()}`);
+        let tempDir;
         try {
-          fs.mkdirSync(tempDir, { recursive: true });
+          tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `${compName}-${compVersion}-`));
           logger.debug(`Created temporary directory: ${tempDir}`);
 
           for (const attachment of matched) {
             const relPath = attachment.out.path;
-            // Include only the part of the path after '_attachments/'
-            const attachmentsSegment = '_attachments/';
             const attachmentsIndex = relPath.indexOf(attachmentsSegment);
 
             if (attachmentsIndex === -1) {
-              logger.warn(`'_attachments/' segment not found in path: ${relPath}. Skipping this file.`);
+              logger.warn(`'${attachmentsSegment}' segment not found in path: ${relPath}. Skipping this file.`);
               continue;
             }
 
@@ -136,42 +136,48 @@ module.exports.register = function ({ config }) {
           }
 
           // Asynchronously create the tar.gz archive in memory
-          logger.debug(`Starting tar creation for ${compName}@${compVersion}`);
-          const archiveBuffer = await createTarInMemory(tempDir);
-          logger.debug(`Tar creation completed for ${compName}@${compVersion}`);
+          try {
+            logger.debug(`Starting tar creation for ${compName}@${compVersion}`);
+            const archiveBuffer = await createTarInMemory(tempDir);
+            logger.debug(`Tar creation completed for ${compName}@${compVersion}`);
 
-          // Define the output path for the archive in the site
-          const archiveOutPath = `${compVer.title}${compVersion ? '-' + compVersion : ''}-${output_archive}`.toLowerCase();
+            // Define the output path for the archive in the site
+            const archiveOutPath = `${compVersion ? compVersion + "-" : ""}${output_archive}`.toLowerCase();
 
-          // Add the archive to siteCatalog
-          siteCatalog.addFile({
-            contents: archiveBuffer,
-            out: { path: archiveOutPath },
-          });
-
-          if (isLatest) {
+            // Add the archive to siteCatalog
             siteCatalog.addFile({
               contents: archiveBuffer,
-              out: { path: path.basename(output_archive) },
+              out: { path: archiveOutPath },
             });
+
+            if (isLatest) {
+              siteCatalog.addFile({
+                contents: archiveBuffer,
+                out: { path: path.basename(output_archive) },
+              });
+            }
+
+            logger.info(`Archive "${archiveOutPath}" added to site.`);
+          } catch (error) {
+            logger.error(`Error creating tar archive for ${compName}@${compVersion}:`, error);
+            continue; // Skip further processing for this version
           }
-
-          logger.info(`Archive "${archiveOutPath}" added to site.`);
-
         } catch (error) {
           logger.error(`Error processing ${compName}@${compVersion}:`, error);
         } finally {
           // Clean up the temporary directory
-          try {
-            fs.rmSync(tempDir, { recursive: true, force: true });
-            logger.debug(`Cleaned up temporary directory: ${tempDir}`);
-          } catch (cleanupError) {
-            logger.error(`Error cleaning up tempDir "${tempDir}":`, cleanupError);
+          if (tempDir) {
+            try {
+              fs.rmSync(tempDir, { recursive: true, force: true });
+              logger.debug(`Cleaned up temporary directory: ${tempDir}`);
+            } catch (cleanupError) {
+              logger.error(`Error cleaning up tempDir "${tempDir}":`, cleanupError);
+            }
           }
         }
       }
     }
 
-    logger.info('Archive creation process completed');
+    logger.info("Archive creation process completed");
   });
 };

--- a/extensions/replace-attributes-in-attachments.js
+++ b/extensions/replace-attributes-in-attachments.js
@@ -5,26 +5,72 @@ const micromatch = require('micromatch');
 const formatVersion = require('./util/format-version.js');
 const sanitize = require('./util/sanitize-attributes.js');
 
+/**
+ * Registers the replace attributes extension with support for multiple replacements.
+ * Each replacement configuration can target specific components and file patterns.
+ *
+ * Configuration Structure:
+ * data:
+ *   replacements:
+ *     - components:
+ *         - 'ComponentName1'
+ *         - 'ComponentName2'
+ *       file_patterns:
+ *         - 'path/to/attachments/**'
+ *         - '/another/path/*.adoc'
+ *       custom_replacements:
+ *         - search: 'SEARCH_REGEX_PATTERN'
+ *           replace: 'Replacement String'
+ *         - ...
+ */
 module.exports.register = function ({ config }) {
   const logger = this.getLogger('replace-attributes-extension');
+  const replacements = config.data?.replacements || [];
 
-  // Retrieve and validate configuration
-  const filePatterns = config.data?.files || [];
-  const userReplacements = config.data?.custom_replacements || [];
-
-  if (filePatterns.length === 0) {
-    logger.warn('No `files` patterns provided. Skipping replacement.');
+  // Validate configuration
+  if (!replacements.length) {
+    logger.info('No `replacements` configurations provided. Replacement process skipped.');
     return;
   }
 
-  // Precompile glob matchers for performance
-  const matchers = micromatch.matcher(filePatterns, { dot: true });
+  // Precompile all glob matchers for performance
+  replacements.forEach((replacementConfig, index) => {
+    const { components, file_patterns } = replacementConfig;
 
-  // Precompile user replacements
-  const compiledUserReplacements = userReplacements.map(({ search, replace }) => ({
-    regex: new RegExp(search, 'g'),
-    replace,
-  }));
+    if (!components || !Array.isArray(components) || !components.length) {
+      logger.warn(`Replacement configuration at index ${index} is missing 'components'. Skipping this replacement configuration.`);
+      replacementConfig.matchers = null;
+      return;
+    }
+
+    if (!file_patterns || !file_patterns.length) {
+      logger.warn(`Replacement configuration at index ${index} is missing 'file_patterns'. Skipping this replacement configuration.`);
+      replacementConfig.matchers = null;
+      return;
+    }
+
+    replacementConfig.matchers = micromatch.matcher(file_patterns, { dot: true });
+  });
+
+  // Precompile all user replacements for each replacement configuration
+  replacements.forEach((replacementConfig, index) => {
+    const { custom_replacements } = replacementConfig;
+    if (!custom_replacements || !custom_replacements.length) {
+      replacementConfig.compiledCustomReplacements = [];
+      return;
+    }
+    replacementConfig.compiledCustomReplacements = custom_replacements.map(({ search, replace }) => {
+      try {
+        return {
+          regex: new RegExp(search, 'g'),
+          replace,
+        };
+      } catch (err) {
+        logger.error(`Invalid regex pattern in custom_replacements for replacement configuration at index ${index}: "${search}"`, err);
+        return null;
+      }
+    }).filter(Boolean); // Remove any null entries due to invalid regex
+  });
 
   this.on('contentClassified', ({ contentCatalog }) => {
     // Build a lookup table: [componentName][version] -> componentVersion
@@ -36,58 +82,100 @@ module.exports.register = function ({ config }) {
       return componentMap;
     }, {});
 
-    // Fetch all attachments
-    const attachments = contentCatalog.findBy({ family: 'attachment' });
-    logger.debug(`Found ${attachments.length} attachments to process.`);
+    // Iterate over each replacement configuration
+    replacements.forEach((replacementConfig, replacementIndex) => {
+      const { components, matchers, compiledCustomReplacements } = replacementConfig;
 
-    attachments.forEach((attachment) => {
-      const { component, version } = attachment.src;
-      const componentVer = componentVersionTable[component]?.[version];
-
-      if (!componentVer?.asciidoc?.attributes) {
-        // Skip attachments without asciidoc attributes
+      if (!components || !matchers) {
+        // Already logged and skipped in precompilation
         return;
       }
 
-      const filePath = attachment.out.path;
+      components.forEach((componentName) => {
+        const comp = contentCatalog.getComponents().find(c => c.name === componentName);
+        if (!comp) {
+          logger.warn(`Component "${componentName}" not found. Skipping replacement configuration at index ${replacementIndex}.`);
+          return;
+        }
 
-      if (!matchers(filePath)) {
-        // Skip files that don't match the patterns
-        return;
-      }
+        comp.versions.forEach((compVer) => {
+          const compName = comp.name;
+          const compVersion = compVer.version;
 
-      logger.debug(`Processing attachment: ${filePath}`);
+          logger.debug(`Processing component version: ${compName}@${compVersion} for replacement configuration at index ${replacementIndex}`);
 
-      // Compute dynamic replacements specific to this componentVersion
-      const dynamicReplacements = getDynamicReplacements(componentVer, logger);
+          // Gather attachments for this component version
+          const attachments = contentCatalog.findBy({
+            component: compName,
+            version: compVersion,
+            family: 'attachment',
+          });
 
-      // Precompile dynamic replacements for this attachment
-      const compiledDynamicReplacements = dynamicReplacements.map(({ search, replace }) => ({
-        regex: new RegExp(search, 'g'),
-        replace,
-      }));
+          logger.debug(`Found ${attachments.length} attachments for ${compName}@${compVersion}`);
 
-      // Combine dynamic and user replacements
-      const allReplacements = [...compiledDynamicReplacements, ...compiledUserReplacements];
+          if (!attachments.length) {
+            logger.debug(`No attachments found for ${compName}@${compVersion}, skipping.`);
+            return;
+          }
 
-      // Convert buffer to string once
-      let contentStr = attachment.contents.toString('utf8');
+          // Filter attachments based on file_patterns
+          const matched = attachments.filter((attachment) => {
+            const filePath = attachment.out.path;
+            return matchers(filePath);
+          });
 
-      // Apply all replacements in a single pass
-      contentStr = applyAllReplacements(contentStr, allReplacements);
+          logger.debug(`Matched ${matched.length} attachments for ${compName}@${compVersion} in replacement configuration at index ${replacementIndex}`);
 
-      // Expand AsciiDoc attributes
-      contentStr = expandAsciiDocAttributes(contentStr, componentVer.asciidoc.attributes);
+          if (!matched.length) {
+            logger.debug(`No attachments matched patterns for ${compName}@${compVersion} in replacement configuration at index ${replacementIndex}, skipping.`);
+            return;
+          }
 
-      // Convert back to buffer
-      attachment.contents = Buffer.from(contentStr, 'utf8');
+          // Process each matched attachment
+          matched.forEach((attachment) => {
+            const { component: attComponent, version: attVersion } = attachment.src;
+            const componentVer = componentVersionTable[attComponent]?.[attVersion];
+
+            if (!componentVer?.asciidoc?.attributes) {
+              // Skip attachments without asciidoc attributes
+              return;
+            }
+
+            const filePath = attachment.out.path;
+
+            logger.debug(`Processing attachment: ${filePath} for replacement configuration at index ${replacementIndex}`);
+
+            // Compute dynamic replacements specific to this componentVersion
+            const dynamicReplacements = getDynamicReplacements(componentVer, logger);
+
+            // Precompile dynamic replacements for this attachment
+            const compiledDynamicReplacements = dynamicReplacements.map(({ search, replace }) => ({
+              regex: new RegExp(search, 'g'),
+              replace,
+            }));
+
+            // Combine dynamic and user replacements
+            const allReplacements = [...compiledDynamicReplacements, ...compiledCustomReplacements];
+
+            // Convert buffer to string once
+            let contentStr = attachment.contents.toString('utf8');
+
+            // Apply all replacements in a single pass
+            contentStr = applyAllReplacements(contentStr, allReplacements);
+
+            // Expand AsciiDoc attributes
+            contentStr = expandAsciiDocAttributes(contentStr, componentVer.asciidoc.attributes);
+
+            // Convert back to buffer
+            attachment.contents = Buffer.from(contentStr, 'utf8');
+          });
+        });
+      });
     });
-  });
+  })
 };
 
-/* -----------------------------
-   Helper: Build dynamic placeholders
------------------------------ */
+// Build dynamic placeholder replacements
 function getDynamicReplacements(componentVersion, logger) {
   const attrs = componentVersion.asciidoc.attributes;
   const isPrerelease = attrs['page-component-version-is-prerelease'];
@@ -119,10 +207,9 @@ function getDynamicReplacements(componentVersion, logger) {
   ];
 }
 
-/* -----------------------------
-   Helper: Apply an array of { regex, replace } to a string in a single pass
------------------------------ */
+// Apply an array of { regex, replace } to a string in a single pass
 function applyAllReplacements(content, replacements) {
+  // Sort replacements by descending length of regex source to handle overlapping patterns
   replacements.sort((a, b) => b.regex.source.length - a.regex.source.length);
 
   replacements.forEach(({ regex, replace }) => {
@@ -132,9 +219,7 @@ function applyAllReplacements(content, replacements) {
   return content;
 }
 
-/* -----------------------------
-   Helper: Expand {my-attribute}
------------------------------ */
+// Expand all existing attributes
 function expandAsciiDocAttributes(content, attributes) {
   return content.replace(/\{([a-z][\p{Alpha}\d_-]*)\}/gu, (match, name) => {
     if (!(name in attributes)) return match;

--- a/extensions/util/format-version.js
+++ b/extensions/util/format-version.js
@@ -1,0 +1,7 @@
+/* -----------------------------
+   Utility: ensure valid semver or fallback
+----------------------------- */
+module.exports = (version, semver) => {
+  if (!version) return null;
+  return semver.valid(version) ? version : `${version}.0`;
+}

--- a/extensions/util/sanitize-attributes.js
+++ b/extensions/util/sanitize-attributes.js
@@ -1,0 +1,6 @@
+/* -----------------------------
+   Utility: remove trailing '@'
+----------------------------- */
+module.exports = (val) => {
+  return String(val).replace('@', '');
+}

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -56,9 +56,9 @@ antora:
         - '**/*.yml'
   - require: './extensions/archive-attachments'
     data:
-      output_archive: redpanda-quickstart.tar.gz
+      output_archive: test.tar.gz
       file_patterns:
-        - "**/test-resources/**/docker-compose/**/*"
+        - "**/*.yaml"
   - require: './extensions/unpublish-pages'
   - require: './extensions/validate-attributes'
   - require: './extensions/find-related-docs'

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -4,6 +4,8 @@ site:
   url: https://docs-extensions-and-macros.netlify.app
 urls:
   html_extension_style: indexify
+output:
+  clean: true
 content:
   sources:
   - url: .
@@ -51,14 +53,20 @@ antora:
   - require: './extensions/unlisted-pages'
   - require: './extensions/replace-attributes-in-attachments'
     data:
-      files:
-        - '**/*.yaml'
-        - '**/*.yml'
+      replacements:
+        - components:
+          - 'ROOT'
+          - 'redpanda-labs'
+          file_patterns:
+            - '**/docker-compose.yaml'
+            - '**/docker-compose.yml'
   - require: './extensions/archive-attachments'
     data:
-      output_archive: test.tar.gz
-      file_patterns:
-        - "**/*.yaml"
+      archives:
+        - component: 'preview'
+          output_archive: 'test.tar.gz'
+          file_patterns:
+            - '**/test.yaml'
   - require: './extensions/unpublish-pages'
   - require: './extensions/validate-attributes'
   - require: './extensions/find-related-docs'

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -50,6 +50,15 @@ antora:
   - require: './extensions/add-pages-to-root'
   - require: './extensions/unlisted-pages'
   - require: './extensions/replace-attributes-in-attachments'
+    data:
+      files:
+        - '**/*.yaml'
+        - '**/*.yml'
+  - require: './extensions/archive-attachments'
+    data:
+      output_archive: redpanda-quickstart.tar.gz
+      file_patterns:
+        - "**/test-resources/**/docker-compose/**/*"
   - require: './extensions/unpublish-pages'
   - require: './extensions/validate-attributes'
   - require: './extensions/find-related-docs'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.11.3",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.11.3",
+      "version": "4.0.0",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "3.11.2",
+      "version": "3.11.3",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",
@@ -20,9 +20,11 @@
         "html-entities": "2.3",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
+        "micromatch": "^4.0.8",
         "node-html-parser": "5.4.2-0",
         "papaparse": "^5.4.1",
-        "semver": "^7.6.0"
+        "semver": "^7.6.0",
+        "tar": "^7.4.3"
       },
       "devDependencies": {
         "@antora/cli": "3.1.4",
@@ -597,6 +599,114 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@octokit/auth-token": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
@@ -765,6 +875,16 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^22.2.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -1707,7 +1827,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -1921,6 +2040,15 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/class-utils": {
@@ -2373,6 +2501,35 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/css-select": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -2701,10 +2858,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -3142,7 +3311,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3208,6 +3376,121 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/findup-sync/node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "license": "MIT",
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/fill-range/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "license": "MIT",
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/fined": {
@@ -3306,6 +3589,22 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/fragment-cache": {
@@ -3685,6 +3984,76 @@
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "license": "MIT",
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/micromatch/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob-watcher/node_modules/micromatch/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4663,6 +5032,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -5135,6 +5519,66 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/matchdep/node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "license": "MIT",
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchdep/node_modules/fill-range/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/matchdep/node_modules/findup-sync": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
@@ -5150,6 +5594,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/matchdep/node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/matchdep/node_modules/is-glob": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
@@ -5162,17 +5615,16 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "dev": true,
+    "node_modules/matchdep/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=0.10.0"
       }
     },
-    "node_modules/micromatch": {
+    "node_modules/matchdep/node_modules/micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
@@ -5196,85 +5648,7 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/micromatch/node_modules/braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-      "license": "MIT",
-      "dependencies": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/micromatch/node_modules/braces/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/micromatch/node_modules/fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/micromatch/node_modules/fill-range/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/micromatch/node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/micromatch/node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/micromatch/node_modules/to-regex-range": {
+    "node_modules/matchdep/node_modules/to-regex-range": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
@@ -5285,6 +5659,29 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/mime": {
@@ -5360,6 +5757,28 @@
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
+      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.4",
+        "rimraf": "^5.0.5"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mixin-deep": {
@@ -5823,6 +6242,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -5932,6 +6357,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -5958,6 +6392,28 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/path-type": {
       "version": "1.1.0",
@@ -6000,7 +6456,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6617,6 +7072,65 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/rollup": {
       "version": "3.29.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
@@ -7023,6 +7537,27 @@
         "sha.js": "bin.js"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/should-proxy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/should-proxy/-/should-proxy-1.0.4.tgz",
@@ -7046,6 +7581,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/simple-concat": {
@@ -7420,6 +7967,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -7430,6 +8022,28 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
@@ -7513,6 +8127,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.17"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/thread-stream": {
@@ -7676,7 +8322,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -7689,7 +8334,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -8300,6 +8944,68 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -8352,6 +9058,15 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
       "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
       "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/yargs": {
       "version": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.11.3",
+  "version": "4.0.0",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",
@@ -30,6 +30,7 @@
       "require": "./extensions/unlisted-pages.js"
     },
     "./extensions/replace-attributes-in-attachments": "./extensions/replace-attributes-in-attachments.js",
+    "./extensions/archive-attachments": "./extensions/archive-attachments.js",
     "./extensions/add-pages-to-root": "./extensions/add-pages-to-root.js",
     "./extensions/collect-bloblang-samples": "./extensions/collect-bloblang-samples.js",
     "./extensions/generate-rp-connect-categories": "./extensions/generate-rp-connect-categories.js",
@@ -72,9 +73,11 @@
     "html-entities": "2.3",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
+    "micromatch": "^4.0.8",
     "node-html-parser": "5.4.2-0",
     "papaparse": "^5.4.1",
-    "semver": "^7.6.0"
+    "semver": "^7.6.0",
+    "tar": "^7.4.3"
   },
   "devDependencies": {
     "@antora/cli": "3.1.4",

--- a/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
@@ -90,7 +90,7 @@ By default, Antora does not replace attributes in attachment files. Download thi
 
 xref:preview:ROOT:attachment$test.yaml[Download attachment]
 
-The archive attachments extension is configured to archive all YAML files for each component version. Test the extension by downloading this archive for the Cloud docs:
+The archive attachments extension is configured to archive all YAML files for the `preview` component. Test the extension by downloading this archive. It should contain the `test.yaml` file and include all replacements made by the replace-attributes-in-attachments extension.
 
 link:/test.tar.gz[Download archive]
 

--- a/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
@@ -92,7 +92,7 @@ xref:preview:ROOT:attachment$test.yaml[Download attachment]
 
 The archive attachments extension is configured to archive all YAML files for each component version. Test the extension by downloading this archive for the Cloud docs:
 
-link:/cloud-test.tar.gz[Download archive]
+link:/test.tar.gz[Download archive]
 
 == Bloblang samples
 

--- a/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
+++ b/preview/extensions-and-macros/modules/ROOT/pages/test.adoc
@@ -90,6 +90,10 @@ By default, Antora does not replace attributes in attachment files. Download thi
 
 xref:preview:ROOT:attachment$test.yaml[Download attachment]
 
+The archive attachments extension is configured to archive all YAML files for each component version. Test the extension by downloading this archive for the Cloud docs:
+
+link:/cloud-test.tar.gz[Download archive]
+
 == Bloblang samples
 
 [,json,subs="attributes+"]


### PR DESCRIPTION
- **Added**: `archive-attachments` extension to automate the archiving of grouped attachments based on configurable file patterns.
- **Enhanced**: `replace-attributes-in-attachments` extension by allowing customizable file patterns and user-defined replacement rules.
- **Breaking change**: The `replace-attributes-in-attachments` extension now requires configuration to specify which attachments should have their text replaced. Previously, the extension worked on all YAML attachments by default, which was inefficient as not all attachments required replacements.

## Motivation

In https://github.com/redpanda-data/docs/pull/937, we introduce a new quickstart that requires users to download multiple files as attachments. To make the UX as streamlined as possible, we want to allow users to download and extract the files in a single archive. Allowing writers to define a group of attachments to use to build an archive reduces manual effort and ensures consistent packaging of related resources.

## Benefits

- **Efficiency**: Automatically creates compressed archives, saving time and minimizing errors.
- **Flexibility**: Configurable file patterns and replacement rules allow precise control over which attachments are archived and how their content is modified.
- **Organization**: Prevents archive overwriting using unique naming conventions, ensuring multiple archives coexist.

## Configuration Example

```yaml
antora:
  extensions:
    - require: '../docs-extensions-and-macros/extensions/archive-attachments.js'
      data:
        archives:
           - component: 'ROOT'
              output_archive: 'redpanda-quickstart.tar.gz'
              file_patterns:
                - '**/test-resources/**/docker-compose/**'
```

## Tests

https://deploy-preview-90--docs-extensions-and-macros.netlify.app/preview/test/#attachments

## Related PRs

Because this is a breaking change and we have an automation that auto-upgrades the package using `latest`, we need to merge these PRs in before we release this new major version of the extension to avoid auto-upgrading to this major version:

- https://github.com/redpanda-data/docs/pull/944
- https://github.com/redpanda-data/cloud-docs/pull/169
- https://github.com/redpanda-data/rp-connect-docs/pull/141