### PR TITLE
Add support for fetching the latest beta release of the Helm chart

### DIFF
--- a/extensions/version-fetcher/get-latest-redpanda-helm-version.js
+++ b/extensions/version-fetcher/get-latest-redpanda-helm-version.js
@@ -1,18 +1,122 @@
+/**
+ * Fetches the latest Helm chart version from GitHub releases.
+ *
+ * This function looks for releases with tags following these patterns:
+ *   - Stable: "redpanda-5.9.21" or "25.1-k8s4" (without "beta" anywhere)
+ *   - Beta: "redpanda-5.9.21-beta", "redpanda-5.9.21-beta.1", or "25.1-k8s4-beta"
+ *
+ * It selects the highest version for each category, fetches the file at the provided path
+ * (typically Chart.yaml) using the tag as the Git ref, parses it, and returns an object with
+ * the chart version from the highest stable release and the highest beta release.
+ *
+ * @param {object} github - The GitHub API client.
+ * @param {string} owner - The repository owner.
+ * @param {string} repo - The repository name.
+ * @param {string} path - The path to the Chart.yaml file in the repository.
+ * @returns {Promise<{ latestStableRelease: string|null, latestBetaRelease: string|null }>}
+ */
 module.exports = async (github, owner, repo, path) => {
   const yaml = require('js-yaml');
   try {
-    const response = await github.repos.getContent({
-      owner: owner,
-      repo: repo,
-      path: path,
+    // Fetch up to 20 releases from GitHub.
+    const releasesResponse = await github.repos.listReleases({
+      owner,
+      repo,
+      per_page: 20,
     });
+    const releases = releasesResponse.data;
 
-    const contentBase64 = response.data.content;
-    const contentDecoded = Buffer.from(contentBase64, 'base64').toString('utf8');
-    const chartYaml = yaml.load(contentDecoded);
-    return chartYaml.version;
+    // Regex patterns:
+    // Stable regex: "redpanda-" prefix, then major.minor with an optional patch,
+    // and no "beta" anywhere in the tag.
+    const stableRegex = /^(?:redpanda-)(\d+)\.(\d+)(?:\.(\d+))?(?!.*beta)/i;
+    // Beta regex: "redpanda-" prefix, then major.minor with an optional patch,
+    // and later somewhere "beta" with an optional numeric qualifier.
+    const betaRegex = /^(?:redpanda-)(\d+)\.(\d+)(?:\.(\d+))?.*beta(?:\.(\d+))?$/i;
+
+    // Filter releases into stable and beta arrays based on tag matching.
+    const stableReleases = releases.filter(release => stableRegex.test(release.tag_name));
+    const betaReleases = releases.filter(release => betaRegex.test(release.tag_name));
+
+    // Sorting function for stable releases.
+    const sortStable = (a, b) => {
+      const aMatch = a.tag_name.match(stableRegex);
+      const bMatch = b.tag_name.match(stableRegex);
+      if (!aMatch || !bMatch) return 0;
+      const aMajor = parseInt(aMatch[1], 10);
+      const aMinor = parseInt(aMatch[2], 10);
+      const aPatch = aMatch[3] ? parseInt(aMatch[3], 10) : 0;
+      const bMajor = parseInt(bMatch[1], 10);
+      const bMinor = parseInt(bMatch[2], 10);
+      const bPatch = bMatch[3] ? parseInt(bMatch[3], 10) : 0;
+      if (aMajor !== bMajor) return bMajor - aMajor;
+      if (aMinor !== bMinor) return bMinor - aMinor;
+      return bPatch - aPatch;
+    };
+
+    // Sorting function for beta releases.
+    const sortBeta = (a, b) => {
+      const aMatch = a.tag_name.match(betaRegex);
+      const bMatch = b.tag_name.match(betaRegex);
+      if (!aMatch || !bMatch) return 0;
+      const aMajor = parseInt(aMatch[1], 10);
+      const aMinor = parseInt(aMatch[2], 10);
+      const aPatch = aMatch[3] ? parseInt(aMatch[3], 10) : 0;
+      // Optional beta number; if not provided, assume 0.
+      const aBeta = aMatch[4] ? parseInt(aMatch[4], 10) : 0;
+      const bMajor = parseInt(bMatch[1], 10);
+      const bMinor = parseInt(bMatch[2], 10);
+      const bPatch = bMatch[3] ? parseInt(bMatch[3], 10) : 0;
+      const bBeta = bMatch[4] ? parseInt(bMatch[4], 10) : 0;
+      if (aMajor !== bMajor) return bMajor - aMajor;
+      if (aMinor !== bMinor) return bMinor - aMinor;
+      if (aPatch !== bPatch) return bPatch - aPatch;
+      return bBeta - aBeta;
+    };
+
+    // Sort both arrays in descending order.
+    stableReleases.sort(sortStable);
+    betaReleases.sort(sortBeta);
+
+    // Get the highest tag from each group, if available.
+    const latestStableTag = stableReleases.length ? stableReleases[0].tag_name : null;
+    const latestBetaTag = betaReleases.length ? betaReleases[0].tag_name : null;
+
+    // Helper function to fetch and parse Chart.yaml from a given tag.
+    const fetchChartVersion = async (tag) => {
+      if (!tag) return null;
+      try {
+        const contentResponse = await github.repos.getContent({
+          owner,
+          repo,
+          path,
+          ref: tag,
+        });
+        const contentBase64 = contentResponse.data.content;
+        const contentDecoded = Buffer.from(contentBase64, 'base64').toString('utf8');
+        const chartYaml = yaml.load(contentDecoded);
+        return chartYaml.version || null;
+      } catch (error) {
+        console.error(`Failed to fetch Chart.yaml for tag ${tag}:`, error.message);
+        return null;
+      }
+    };
+
+    const [latestStableReleaseVersion, latestBetaReleaseVersion] = await Promise.all([
+      fetchChartVersion(latestStableTag),
+      fetchChartVersion(latestBetaTag)
+    ]);
+
+    return {
+      latestStableRelease: latestStableReleaseVersion,
+      latestBetaRelease: latestBetaReleaseVersion
+    };
+
   } catch (error) {
     console.error('Failed to fetch chart version:', error.message);
-    return null
+    return {
+      latestStableRelease: null,
+      latestBetaRelease: null
+    };
   }
 };

--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -50,8 +50,6 @@ module.exports.register = function ({ config }) {
         connect: latestConnectResult.status === 'fulfilled' ? latestConnectResult.value : undefined,
       };
 
-      console.log(latestVersions)
-
       const components = await contentCatalog.getComponents();
       components.forEach(component => {
         const prerelease = component.latestPrerelease;
@@ -64,7 +62,7 @@ module.exports.register = function ({ config }) {
           // Set operator and helm chart attributes via helper function
           updateAttributes(asciidoc, [
             { condition: latestVersions.operator, key: 'latest-operator-version', value: latestVersions.operator?.latestStableRelease },
-            { condition: latestVersions.helmChart, key: 'latest-redpanda-helm-chart-version', value: latestVersions.helmChart }
+            { condition: latestVersions.helmChart, key: 'latest-redpanda-helm-chart-version', value: latestVersions.helmChart?.latestStableRelease }
           ]);
 
           // Set attributes for console and connect versions
@@ -87,6 +85,9 @@ module.exports.register = function ({ config }) {
           }
           if (latestVersions.operator?.latestBetaRelease) {
             setVersionAndTagAttributes(asciidoc, 'operator-beta', latestVersions.operator.latestBetaRelease, name, version);
+          }
+          if (latestVersions.helmChart?.latestBetaRelease) {
+            setVersionAndTagAttributes(asciidoc, 'helm-beta', latestVersions.helmChart.latestBetaRelease, name, version);
           }
         });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
This pull request includes significant updates to the `version-fetcher` extension, particularly in the `get-latest-redpanda-helm-version.js` and `set-latest-version.js` files, to improve the fetching and setting of the latest Helm chart versions. Additionally, there is a minor version bump in the `package.json` file.

### Improvements to version-fetching logic:

* [`extensions/version-fetcher/get-latest-redpanda-helm-version.js`](diffhunk://#diff-672b9d254d419cf606642a37433491455b20e32f033c6799ca0fbb0a36d13f04R1-R120): Enhanced the function to fetch and parse the latest stable and beta Helm chart versions from GitHub releases, including sorting and regex matching for version tags.

### Improvements to version-setting logic:

* [`extensions/version-fetcher/set-latest-version.js`](diffhunk://#diff-5cd8ae7b1e263399cce36e51a4183fc7c742a2811d05949937176f949aaa63e4L53-L54): Updated the logic to set the latest Helm chart version attributes in Asciidoc, ensuring both stable and beta versions are handled correctly. [[1]](diffhunk://#diff-5cd8ae7b1e263399cce36e51a4183fc7c742a2811d05949937176f949aaa63e4L53-L54) [[2]](diffhunk://#diff-5cd8ae7b1e263399cce36e51a4183fc7c742a2811d05949937176f949aaa63e4L67-R65) [[3]](diffhunk://#diff-5cd8ae7b1e263399cce36e51a4183fc7c742a2811d05949937176f949aaa63e4R89-R91)

### Version bump:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Incremented the package version from `4.2.1` to `4.2.2`.