### PR TITLE
Fix custom replacements

### DIFF
--- a/extensions/replace-attributes-in-attachments.js
+++ b/extensions/replace-attributes-in-attachments.js
@@ -213,7 +213,8 @@ function applyAllReplacements(content, replacements) {
   replacements.sort((a, b) => b.regex.source.length - a.regex.source.length);
 
   replacements.forEach(({ regex, replace }) => {
-    content = content.replace(regex, replace);
+    const freshRegex = new RegExp(regex.source, regex.flags);
+    content = content.replace(freshRegex, replace);
   });
 
   return content;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.2.1",
+  "version": "4.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.2.1",
+      "version": "4.2.3",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
This pull request includes a change to the `applyAllReplacements` function in `extensions/replace-attributes-in-attachments.js` to ensure that each regex replacement uses a fresh regular expression object. This modification prevents potential issues caused by reusing the same regex object with different replacements.

* [`extensions/replace-attributes-in-attachments.js`](diffhunk://#diff-9532e6ee5af06dee5442ee46e82b23ebc9faaaf92138d8c0afb24078a6fb3003L216-R217): Updated the `applyAllReplacements` function to create a new `RegExp` object for each replacement to avoid side effects from reused regex objects.