### PR TITLE
Do not use draft releases for latest Redpanda version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.2.3",
+      "version": "4.2.4",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
Previously, the version fetcher would consider any release (draft or not) stable if it didn't include 'RC'. However, for this release, we tagged `v25.1.1` early as a draft, and our script considers this a stable release, so our quickstart automatically references v25.1.1 even though it hasn't yet been released.

To fix this issue, this pull request filters out draft releases for non-RC versions.

Improvements to version fetching:

* [`extensions/version-fetcher/get-latest-redpanda-version.js`](diffhunk://#diff-0461edd15f4e79c459647f848b790f0e5a3151be0c8e201914c9896e0a13cb79L14-L53): Refactored the code to filter valid semver tags and sort them more efficiently.
* [`extensions/version-fetcher/get-latest-redpanda-version.js`](diffhunk://#diff-0461edd15f4e79c459647f848b790f0e5a3151be0c8e201914c9896e0a13cb79L14-L53): Improved logic to find the latest non-RC release that is not a draft, and the latest RC release, regardless of draft status.
* [`extensions/version-fetcher/get-latest-redpanda-version.js`](diffhunk://#diff-0461edd15f4e79c459647f848b790f0e5a3151be0c8e201914c9896e0a13cb79L14-L53): Modified the retrieval of commit hashes for the latest releases to handle cases where no valid releases are found.

Version bump:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `4.2.3` to `4.2.4`.