### PR TITLE
Fetch Console tags from Docker Hub

### DIFF
--- a/extensions/version-fetcher/set-latest-version.js
+++ b/extensions/version-fetcher/set-latest-version.js
@@ -3,7 +3,7 @@
 module.exports.register = function ({ config }) {
   const GetLatestRedpandaVersion = require('./get-latest-redpanda-version');
   const GetLatestConsoleVersion = require('./get-latest-console-version');
-  const GetLatestOperatorVersion = require('./fetch-latest-docker-tag');
+  const GetLatestDockerTag = require('./fetch-latest-docker-tag');
   const GetLatestHelmChartVersion = require('./get-latest-redpanda-helm-version');
   const GetLatestConnectVersion = require('./get-latest-connect');
   const logger = this.getLogger('set-latest-version-extension');
@@ -36,8 +36,8 @@ module.exports.register = function ({ config }) {
         latestConnectResult,
       ] = await Promise.allSettled([
         GetLatestRedpandaVersion(github, owner, 'redpanda'),
-        GetLatestConsoleVersion(github, owner, 'console'),
-        GetLatestOperatorVersion(dockerNamespace, 'redpanda-operator'),
+        GetLatestDockerTag(dockerNamespace, 'console'),
+        GetLatestDockerTag(dockerNamespace, 'redpanda-operator'),
         GetLatestHelmChartVersion(github, owner, 'helm-charts', 'charts/redpanda/Chart.yaml'),
         GetLatestConnectVersion(github, owner, 'connect'),
       ]);

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -12,7 +12,7 @@ content:
     branches: HEAD
     start_paths: [preview/extensions-and-macros, preview/shared]
   - url: https://github.com/redpanda-data/docs
-    branches: [v/*, api, v-WIP/24.3, 'site-search', '!v-end-of-life/*']
+    branches: [main, v/*, api, v-WIP/24.3, 'site-search', '!v-end-of-life/*']
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -12,7 +12,7 @@ content:
     branches: HEAD
     start_paths: [preview/extensions-and-macros, preview/shared]
   - url: https://github.com/redpanda-data/docs
-    branches: [main, v/*, api, v-WIP/24.3, 'site-search', '!v-end-of-life/*']
+    branches: [v/*, api, v-WIP/24.3, 'site-search', '!v-end-of-life/*']
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.2.4",
+      "version": "4.2.5",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
Redpanda Console v3.0.0 has been released on Docker Hub but not in GitHub.

Since our quickstart relies on the Docker tags, this PR updates the version fetching logic for Console to rely on Docker tags instead of GitHub releases.