### PR TITLE
Allow for unknown types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.6.5",
+  "version": "4.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.6.5",
+      "version": "4.6.6",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.6.5",
+  "version": "4.6.6",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/tools/redpanda-connect/helpers/renderConnectFields.js
+++ b/tools/redpanda-connect/helpers/renderConnectFields.js
@@ -26,12 +26,10 @@ module.exports = function renderConnectFields(children, prefix = '') {
   sorted.forEach(child => {
     if (child.is_deprecated || !child.name) return;
 
-    // Normalize type: arrays and unknown-map as object
+    // Normalize types
     let displayType;
     if (child.type === 'string' && child.kind === 'array') {
       displayType = 'array';
-    } else if (child.type === 'unknown' && child.kind === 'map') {
-      displayType = 'object';
     } else {
       displayType = child.type;
     }


### PR DESCRIPTION
`unknown` is a valid type in Redpanda Connect (not a bug like we previously thought). This PR removes the logic that maps `unknown` types to objects: https://github.com/redpanda-data/connect/blob/main/docs/modules/configuration/pages/templating.adoc#fieldstype