### PR TITLE
Handle unknown types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.6.6",
+  "version": "4.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.6.6",
+      "version": "4.6.7",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.6.6",
+  "version": "4.6.7",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/tools/redpanda-connect/helpers/renderConnectFields.js
+++ b/tools/redpanda-connect/helpers/renderConnectFields.js
@@ -30,6 +30,12 @@ module.exports = function renderConnectFields(children, prefix = '') {
     let displayType;
     if (child.type === 'string' && child.kind === 'array') {
       displayType = 'array';
+    } else if (child.type === 'unknown' && child.kind === 'map') {
+      displayType = 'object';
+    } else if (child.type === 'unknown' && child.kind === 'array') {
+      displayType = 'array';
+    } else if (child.type === 'unknown' && child.kind === 'list') {
+      displayType = 'array';
     } else {
       displayType = child.type;
     }


### PR DESCRIPTION
This pull request updates the `renderConnectFields` function to handle additional cases for determining the `displayType` of child elements. The most important change is the addition of logic to handle `unknown` types with specific `kind` values.

Enhancements to `displayType` determination:

* [`tools/redpanda-connect/helpers/renderConnectFields.js`](diffhunk://#diff-9fd0395539c5e466ea0c3bb73e7f6cb16928551adfdf9e6cd099d49bebfa5afdR33-R38): Added conditions to set `displayType` to `object` when `child.type` is `unknown` and `child.kind` is `map`, and to `array` when `child.type` is `unknown` and `child.kind` is `array` or `list`.