### PR TITLE
Fix the syntax error in property extractor tool

### DIFF
--- a/bin/doc-tools.js
+++ b/bin/doc-tools.js
@@ -308,8 +308,8 @@ To fix this on macOS:
    sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
 
 4. Verify the fix:
-   echo '#include <functional>' | ${cppCompiler || 'clang++'} -x c++ -fsyntax-only -
-
+   echo '#include <functional>' | \${cppCompiler || 'clang++'} -x c++ -fsyntax-only -
+`);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.6.8",
+  "version": "4.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.6.8",
+      "version": "4.6.9",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.6.8",
+  "version": "4.6.9",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",

--- a/tools/property-extractor/requirements.txt
+++ b/tools/property-extractor/requirements.txt
@@ -1,2 +1,2 @@
-tree_sitter==0.20.4
+tree_sitter==0.21.1
 setuptools>=42.0.0


### PR DESCRIPTION
This pull request includes minor version updates to dependencies in the project. The updates ensure compatibility with the latest features and bug fixes.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `4.6.8` to `4.6.9`.
* [`tools/property-extractor/requirements.txt`](diffhunk://#diff-170788fba9b199710ffde92965ac56c1e0a52cf746c624045dec8bedcc4ace4fL1-R1): Upgraded the `tree_sitter` dependency from version `0.20.4` to `0.21.1`.