### PR TITLE
Add commander as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/rest": "^21.0.1",
         "algoliasearch": "^4.17.0",
         "chalk": "4.1.2",
-        "commander": "~10.0",
+        "commander": "^14.0.0",
         "gulp": "^4.0.2",
         "gulp-connect": "^5.7.0",
         "handlebars": "^4.7.8",
@@ -263,6 +263,16 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@antora/cli/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@antora/content-aggregator": {
@@ -3794,12 +3804,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/component-emitter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@octokit/rest": "^21.0.1",
         "algoliasearch": "^4.17.0",
         "chalk": "4.1.2",
+        "commander": "~10.0",
         "gulp": "^4.0.2",
         "gulp-connect": "^5.7.0",
         "handlebars": "^4.7.8",
@@ -3796,7 +3797,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
       "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@octokit/rest": "^21.0.1",
     "algoliasearch": "^4.17.0",
     "chalk": "4.1.2",
+    "commander": "~10.0",
     "gulp": "^4.0.2",
     "gulp-connect": "^5.7.0",
     "handlebars": "^4.7.8",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@octokit/rest": "^21.0.1",
     "algoliasearch": "^4.17.0",
     "chalk": "4.1.2",
-    "commander": "~10.0",
+    "commander": "^14.0.0",
     "gulp": "^4.0.2",
     "gulp-connect": "^5.7.0",
     "handlebars": "^4.7.8",


### PR DESCRIPTION
In our content repos, the CLI worked because `commander` is a dependency in the Antora CLI package, which is available in all our content repos anyway. However, when trying to run this having installed only `@redpanda-data/docs-extensions-and-macros`, it'll fail with `Error: Cannot find module 'commander'`. We found this in the new `api-docs` repo: https://github.com/redpanda-data/api-docs/actions/runs/16598884441/job/46952681064

This PR adds the `commander` package explicity to avoid such issues.