### PR TITLE
Do not create a tag for the Home component

### DIFF
--- a/extensions/algolia-indexer/generate-index.js
+++ b/extensions/algolia-indexer/generate-index.js
@@ -187,6 +187,9 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
       const allComponentTitles = componentsList
         .map(c => (c.title || '').trim())
         .filter(t => t && t.toLowerCase() !== 'home');
+      if (!allComponentTitles.length) {
+        throw new Error('No component titles found for "home" page. Indexing aborted.');
+      }
       tag = [...new Set(allComponentTitles)];
     } else {
       tag = `${title}${version ? ' v' + version : ''}`;

--- a/extensions/algolia-indexer/generate-index.js
+++ b/extensions/algolia-indexer/generate-index.js
@@ -175,7 +175,16 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
       .replace(/\s+/g, ' ')
       .trim();
 
-    var tag = `${component.title} ${version ? 'v' + version : ''}`.trim();
+    let tag;
+    if (component.title === 'home') {
+      // Collect all unique component titles except 'home'
+      const allComponentTitles = Object.values(contentCatalog.components || contentCatalog._components || {})
+        .map(c => c.title)
+        .filter(title => title && title !== 'home');
+      tag = Array.from(new Set(allComponentTitles));
+    } else {
+      tag = `${component.title} ${version ? 'v' + version : ''}`.trim();
+    }
     var indexItem;
     const deployment = page.asciidoc?.attributes['env-kubernetes'] ? 'Kubernetes' : page.asciidoc?.attributes['env-linux'] ? 'Linux' : page.asciidoc?.attributes['env-docker'] ? 'Docker' : page.asciidoc?.attributes['page-cloud'] ? 'Redpanda Cloud' : ''
 
@@ -198,12 +207,12 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
       indexItem.product = component.title;
       indexItem.breadcrumbs = breadcrumbs;
       indexItem.type = 'Doc';
-      indexItem._tags = [tag];
+      indexItem._tags = Array.isArray(tag) ? tag : [tag];
     } else {
       indexItem.deployment = deployment;
       indexItem.type = 'Lab';
       indexItem.interactive = false;
-      indexItem._tags = [tag];
+      indexItem._tags = Array.isArray(tag) ? tag : [tag];
     }
     algolia[cname][version].push(indexItem)
     algoliaCount++

--- a/extensions/algolia-indexer/generate-index.js
+++ b/extensions/algolia-indexer/generate-index.js
@@ -176,14 +176,20 @@ function generateIndex (playbook, contentCatalog, { indexLatestOnly = false, exc
       .trim();
 
     let tag;
-    if (component.title === 'home') {
-      // Collect all unique component titles except 'home'
-      const allComponentTitles = Object.values(contentCatalog.components || contentCatalog._components || {})
-        .map(c => c.title)
-        .filter(title => title && title !== 'home');
-      tag = Array.from(new Set(allComponentTitles));
+    const title = (component.title || '').trim();
+    if (title.toLowerCase() === 'home') {
+      // Collect all unique component titles except 'home' using public API when available
+      const componentsList = typeof contentCatalog.getComponents === 'function'
+        ? contentCatalog.getComponents()
+        : Array.isArray(contentCatalog.components)
+          ? contentCatalog.components
+          : Object.values(contentCatalog.components || contentCatalog._components || {});
+      const allComponentTitles = componentsList
+        .map(c => (c.title || '').trim())
+        .filter(t => t && t.toLowerCase() !== 'home');
+      tag = [...new Set(allComponentTitles)];
     } else {
-      tag = `${component.title} ${version ? 'v' + version : ''}`.trim();
+      tag = `${title}${version ? ' v' + version : ''}`;
     }
     var indexItem;
     const deployment = page.asciidoc?.attributes['env-kubernetes'] ? 'Kubernetes' : page.asciidoc?.attributes['env-linux'] ? 'Linux' : page.asciidoc?.attributes['env-docker'] ? 'Docker' : page.asciidoc?.attributes['page-cloud'] ? 'Redpanda Cloud' : ''

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redpanda-data/docs-extensions-and-macros",
-      "version": "4.7.2",
+      "version": "4.7.3",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redpanda-data/docs-extensions-and-macros",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "description": "Antora extensions and macros developed for Redpanda documentation.",
   "keywords": [
     "antora",


### PR DESCRIPTION
Users won't ever choose to filter by the content in 'Home' so it shouldn't be a tag.

This pull request updates the way tags are generated and assigned when indexing documentation content, particularly handling the special case for components titled 'home'. It also bumps the package version to 4.7.3.

Improvements to tag generation and assignment:

* Updated `generate-index.js` so that if the component title is `'home'`, the tag is set to a list of all unique component titles (excluding `'home'`). For other components, the tag remains as the component title and version.
* Modified the assignment of the `_tags` property to ensure it is always an array, whether the tag is a string or already an array.

Version update:

* Bumped the package version in `package.json` from `4.7.2` to `4.7.3`.